### PR TITLE
Remove --strict from PR build #82

### DIFF
--- a/.github/workflows/pr-mkdocs.yml
+++ b/.github/workflows/pr-mkdocs.yml
@@ -15,5 +15,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install mkdocs-material
-      - run: mkdocs build --strict
+      - run: mkdocs build 
         working-directory: ./site


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Fixes: #82

* Removes '--strict' from PR build, which will mean that the check will still pass even with link warnings (and we get many as the docs are work in progress)
* Warnings ARE still logged, but the developer should check reports locally and/or output from the build action
* With this in place we can ENFORCE this PR check to prevent MERGEs where the docs will definitely not build