### PR TITLE
Revert "#94 correct broken k8s docs"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 
 # Mac files
 .DS_Store
-
 /site/site

--- a/site/docs/guides/admin/kubernetes/chart_base.md
+++ b/site/docs/guides/admin/kubernetes/chart_base.md
@@ -1,0 +1,199 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Base Egeria (egeria-base)
+
+This is a simple deployment of Egeria which will just deploy a basic Egeria environment
+which is ready for you to experiment with. Specifically it sets up
+
+- A single egeria platform which hosts
+    - An egeria metadata server with a persistent graph store
+    - A new server to support the UI
+- A UI to allow browsing of types, instances & servers
+- Apache Kafka & Zookeeper
+
+It does not provide access to our lab notebooks, the Polymer based UI, nor is it preloaded with any data.
+
+This chart may also be useful to understand how to deploy Egeria within kubernetes. In future we anticipate providing
+an [operator](https://github.com/odpi/egeria-k8s-operator) which will be more flexible
+
+## Prerequisites
+
+In order to use the labs, you'll first need to have the following installed:
+
+- A Kubernetes cluster at 1.15 or above
+- the `kubectl` tool in your path
+- [Helm](https://github.com/helm/helm/releases) 3.0 or above
+
+No configuration of the chart is required to use defaults, but information is provided below
+
+## Installation
+
+From one directory level above the location of this README, run the following:
+
+```bash
+helm dep update egeria-base
+helm install egeria egeria-base
+```
+
+THE INSTALL WILL TAKE SEVERAL MINUTES
+
+This is because it is not only creating the required
+objects in Kubernetes to run the platforms, but also is configuring egeria itself - which involves waiting
+for everything to startup before configuring Egeria via REST API calls.
+
+Once installed the configured server is set to start automatically, storage is persisted, and so if your pod gets moved/restarted, egeria should come back automatically with the same data as before.
+
+### Additional Install Configuration
+
+This section is optional - skip over if you're happy with defaults - a good idea to begin with.
+
+In a helm chart the configuration that has been externalised by the chart writer is specified in the `values.yaml` file which you can find in this directory. However rather than edit this file directly, it's recommended you create an additional file with the required overrides.
+
+As an example, in `values.yaml` we see a value 'serverName' which is set to mds1. If I want to override this I could do
+```bash
+helm install --set-string egeria.serverName=myserver
+```
+However this can get tedious with multiple values to override, and you need to know the correct types to use.
+
+Instead it may be easier to create an additional file. For example let's create a file in my home directory `~/egeria.yaml` containing:
+```
+egeria:
+  serverName: metadataserver
+  viewServerName: presentationview
+```
+We can then install the chart with:
+```bash
+helm install -f ~/egeria.yaml egeria egeria-base
+```
+
+Up to now the installation has been called `egeria` but we could call it something else ie `metadataserver`
+```bash
+helm install -f ~/egeria.yaml metadataserver egeria-base
+```
+
+This is known as a `release` in Helm, and we can have multiple installed currently.
+
+To list these use
+```bash
+helm list
+```
+and to delete both names we've experimented with so far:
+```bash
+helm delete metadataserver
+helm delete egeria
+```
+
+Refer to the comments in `values.yaml` for further information on what can be configured - this includes:
+- server, organization, cohort names
+- storage options - k8s storage class/size
+- Egeria version
+- Kubernetes service setup (see below also)
+- roles & accounts
+- timeouts
+- names & repositories for docker images used by the chart
+- Kafka specific configuration (setup in the Bitnami chart we use)
+
+### Using additional connectors
+
+If you have additional Egeria connectors that are needed in your deployment, you should soon be able to include the following when deploying the chart
+
+```bash
+helm install --include-dir libs=~/libs egeria egeria-base
+```
+Where in this example ~/libs is the directory including the additional connectors you wish to use.
+
+However the support for this is awaiting a [helm PR](https://github.com/helm/helm/pull/8841), so in the meantime please copy files directly into a 'libs' directory within the chart instead.
+
+For example
+```bash
+mkdir egeria-base/libs
+cp ~/libs/*jar egeria-base/libs
+```
+
+These files will be copied into a kubernetes config map, which is then made available as a mounted volume to the runtime image of egeria & added to the class loading path as `/extlib`. You still need to configure the egeria server(s) appropriately
+## Accessing Egeria
+
+When this chart is installed, an initialization job is run to configure the egeria metadata server and UI.
+
+For example looking at kubernetes jobs will show something like:
+```bash
+$ kubectl get pods                                                                                      [17:27:11]
+NAME                                        READY   STATUS    RESTARTS   AGE
+egeria-base-config-crhrv                    1/1     Running   0          4m16s
+egeria-base-platform-0                      1/1     Running   0          4m16s
+egeria-base-presentation-699669cfd4-9swjb   1/1     Running   0          4m16s
+egeria-kafka-0                              1/1     Running   2          4m16s
+egeria-zookeeper-0                          1/1     Running   0          4m16s
+```
+
+You should wait until that first 'egeria-base-config' job completes, it will then disappear from the list.
+This job issues REST calls against the egeria serves to configure them for this simple environment (see scripts directory).
+
+The script will not run again, since we will have now configured the servers with persistent storage, and for the platform
+to autostart our servers. So even if a pod is removed and restarted, the egeria platform and servers should return in the same state.
+
+We now have egeria running within a Kubernetes cluster, but by default no services are exposed externally - they are all of type `ClusterIP` - we can see these with
+
+```bash
+$ kubectl get services                                                                                                                                                                                                                                [12:38:16]
+NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP                         PORT(S)                      AGE
+egeria-kafka                ClusterIP      172.21.42.105    <none>                              9092/TCP                     33m
+egeria-kafka-headless       ClusterIP      None             <none>                              9092/TCP,9093/TCP            33m
+egeria-platform             ClusterIP      172.21.40.79     <none>                              9443/TCP                     33m
+egeria-presentation         ClusterIP      172.21.107.242   <none>                              8091/TCP                     33m
+egeria-zookeeper            ClusterIP      172.21.126.56    <none>                              2181/TCP,2888/TCP,3888/TCP   33m
+egeria-zookeeper-headless   ClusterIP      None             <none>                              2181/TCP,2888/TCP,3888/TCP   33m
+```
+
+The `egeria-presentation` service is very useful to expose as this provides a useful UI where you can explore
+types and instances. Also `egeria-platform` is the service for egeria itself. In production you might want this only exposed very carefully to other systems - and not other users or the internet, but for experimenting with egeria let's assume you do.
+
+How these are exposed can be somewhat dependent on the specific kubernetes environment you are using.
+
+In the [lab chart](chart_lab.md) we provided an example of using `kubectl port-forward`. Here we use RedHat OpenShift in IBM Cloud, where you can expose these services via a LoadBalancer using
+
+```
+kubectl expose service/egeria-presentation --type=LoadBalancer --port=8091 --target-port=8091 --name pres  
+kubectl expose service/egeria-platform --type=LoadBalancer --port=9443 --target-port=9443 --name platform   
+```
+
+If I run these, and then look again at my services I see I now have 2 additional entries (modified for obfuscation):
+```
+platform                    LoadBalancer   172.21.218.241   3bc644c3-eu-gb.lb.appdomain.cloud   9443:30640/TCP               25h
+pres                        LoadBalancer   172.21.18.10     42b0c7f5-eu-gb.lb.appdomain.cloud   8091:30311/TCP               22h
+```
+
+So I can access them at their respective hosts. Note that where hosts are allocated dynamically, it can take up to an hour or more for DNS caches to refresh. Waiting up to 5 minutes then refreshing a local cache has proven sufficient for me, but your experience may differ.
+
+In the example above, the Egeria UI can be accessed at `https://42b0c7f5-eu-gb.lb.appdomain.cloud:8091/org/` . Replace the hostname accordingly, and also the `org` is the organization name from the `Values.yaml` file we referred to above
+
+Once logged in, you should be able to login using our demo userid/password of `garygeeke/admin` & start browsing types and instances within Egeria.
+
+You can also issue REST API calls against egeria using a base URL for the platform of `https://3bc644c3-eu-gb.lb.appdomain.cloud` - Other material
+covers these REST API calls in more detail, but a simple api doc is available at `https://3bc644c3-eu-gb.lb.appdomain.cloud/swagger-ui.html`
+## Cleaning up / removing Egeria
+
+To delete the deployment, simply run this for Helm3:
+
+```bash
+$ helm delete egeria
+```
+
+In addition, the egeria chart makes use of persistent storage. To remove these use
+```bash
+$ kubectl get pvc
+NAME                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                 AGE
+data-egeria-kafka-0                         Bound    pvc-d31e0012-8568-4e6f-ae5d-94832ebcd92d   10Gi       RWO            ibmc-vpc-block-10iops-tier   48m
+data-egeria-zookeeper-0                     Bound    pvc-90739fce-dce0-422b-8738-a38293d8fdfb   10Gi       RWO            ibmc-vpc-block-10iops-tier   48m
+egeria-egeria-data-egeria-base-platform-0   Bound    pvc-197ba47e-a6d5-4f35-a7d8-7b7ec1ed1df3   10Gi       RWO            ibmc-vpc-block-10iops-tier   48m
+```
+Identify those associated with egeria - which should be obvious from the name and then delete with
+```bash
+kubectl delete pvc <id>
+```
+
+See the section on Configuration for more details
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/chart_lab.md
+++ b/site/docs/guides/admin/kubernetes/chart_lab.md
@@ -1,0 +1,204 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# Lab - Coco Pharmaceuticals (odpi-egeria-lab)
+
+This example is intended to replicate the metadata landscape of a hypothetical company, Coco Pharmaceuticals, and allow you to understand a little more about how Egeria can help, and how to use it. This forms our 'Hands on Lab'.
+
+The Helm chart will deploy the following components, all in a self-contained environment,
+ allowing you to explore Egeria and its concepts safely
+and repeatably:
+
+- Multiple Egeria servers
+- Apache Kafka (and its Zookeeper dependency)
+- Example Jupyter Notebooks
+- Jupyter runtime
+- Egeria's React based UI
+
+## Prerequisites
+
+In order to use the labs, you'll first need to have the following installed:
+
+- Kubernetes 1.15 or above
+- Helm 3.0 or above
+- Egeria chart repository configured & updated
+
+6GB RAM minimum is recommended for your k8s environment.
+
+You no longer need a git clone of this repository to install the chart.
+
+## Installation
+
+```bash
+helm install lab egeria/odpi-egeria-lab
+```
+
+In the following examples we're using microk8s.
+
+```bash
+$ helm install lab egeria/odpi-egeria-lab                                                                            [11:47:04]
+WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/snap/microk8s/2346/credentials/client.config
+NAME: lab
+LAST DEPLOYED: Tue Aug 10 11:47:19 2021
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+ODPi Egeria lab tutorial
+---
+```
+Some additional help text is also output, which is truncated for brevity.
+
+It can take a few seconds for the various components to all spin-up. You can monitor
+the readiness by running `kubectl get all` -- when ready, you should see output like the following:
+
+```bash
+$ kubectl get all                                                                                                     [13:53:43]
+NAME                                                   READY   STATUS    RESTARTS   AGE
+pod/lab-odpi-egeria-lab-ui-74cc464575-cf8rm            1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-datalake-0                     1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-nginx-7b96949b4f-7dff4         1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-presentation-bd9789747-rbv69   1/1     Running   0          126m
+pod/lab-kafka-0                                        1/1     Running   0          126m
+pod/lab-zookeeper-0                                    1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-dev-0                          1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-uistatic-7b98d4bf9b-sf9bj      1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-core-0                         1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-factory-0                      1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-jupyter-77b6868c4-9hnlp        1/1     Running   0          126m
+
+NAME                                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
+service/kubernetes                    ClusterIP   10.152.183.1     <none>        443/TCP                      20h
+service/lab-kafka-headless            ClusterIP   None             <none>        9092/TCP,9093/TCP            126m
+service/lab-zookeeper-headless        ClusterIP   None             <none>        2181/TCP,2888/TCP,3888/TCP   126m
+service/lab-zookeeper                 ClusterIP   10.152.183.25    <none>        2181/TCP,2888/TCP,3888/TCP   126m
+service/lab-jupyter                   ClusterIP   10.152.183.172   <none>        8888/TCP                     126m
+service/lab-core                      ClusterIP   10.152.183.248   <none>        9443/TCP                     126m
+service/lab-nginx                     ClusterIP   10.152.183.155   <none>        443/TCP                      126m
+service/lab-datalake                  ClusterIP   10.152.183.191   <none>        9443/TCP                     126m
+service/lab-dev                       ClusterIP   10.152.183.122   <none>        9443/TCP                     126m
+service/lab-kafka                     ClusterIP   10.152.183.79    <none>        9092/TCP                     126m
+service/lab-odpi-egeria-lab-factory   ClusterIP   10.152.183.158   <none>        9443/TCP                     126m
+service/lab-uistatic                  ClusterIP   10.152.183.156   <none>        80/TCP                       126m
+service/lab-presentation              ClusterIP   10.152.183.61    <none>        8091/TCP                     126m
+service/lab-ui                        ClusterIP   10.152.183.186   <none>        8443/TCP                     126m
+
+NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/lab-odpi-egeria-lab-presentation   1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-nginx          1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-ui             1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-uistatic       1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-jupyter        1/1     1            1           126m
+
+NAME                                                         DESIRED   CURRENT   READY   AGE
+replicaset.apps/lab-odpi-egeria-lab-presentation-bd9789747   1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-nginx-7b96949b4f         1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-ui-74cc464575            1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-uistatic-7b98d4bf9b      1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-jupyter-77b6868c4        1         1         1       126m
+
+NAME                                            READY   AGE
+statefulset.apps/lab-odpi-egeria-lab-dev        1/1     126m
+statefulset.apps/lab-zookeeper                  1/1     126m
+statefulset.apps/lab-kafka                      1/1     126m
+statefulset.apps/lab-odpi-egeria-lab-core       1/1     126m
+statefulset.apps/lab-odpi-egeria-lab-datalake   1/1     126m
+statefulset.apps/lab-odpi-egeria-lab-factory    1/1     126m
+````
+
+All of the `pod/...` listed at the top have `Running` as their `STATUS` and `1/1` under `READY`.)
+
+## Accessing the Jupyter notebooks
+
+We now need to get connectivity to the interesting pods, such as that running the Jupyer notebook server, as this is where you'll get to the examples.
+
+Since k8s implementations vary one simple approach for local testing is to use `kubectl port-forward` to connect to the relevant service.
+
+If you look in the list of services above (`kubectl get services`) we have one named 'service/lab-jupyter' so let's try that (with microk8s):
+```shell
+$ kubectl port-forward service/lab-jupyter 8888:8888                                                                  [13:53:52]
+Forwarding from 127.0.0.1:8888 -> 8888
+Forwarding from [::1]:8888 -> 8888
+```
+This command will not return - the port forwarding is active whilst it's running. In this example we're forwarding all requests to local port 8888 to the k8s service for jupyter
+
+At this point you should be able to access your notebooks by going to this forwarded port ie 'http://localhost:8888'
+
+## Accessing the React UI
+
+We repeat the port forwarding above, this time for another service
+```shell
+$ kubectl port-forward service/lab-presentation 8091:8091                                                             [14:15:37]
+Forwarding from 127.0.0.1:8091 -> 8091
+Forwarding from [::1]:8091 -> 8091
+```
+As before, you can define an Ingress, or use nodeports instead if preferred.
+
+Now go to https://localhost:8091/coco to access the React UI. Login as 'garygeeke',password 'admin'.
+
+## Accessing the Egeria UI
+
+The same applies to the service exposing Egeria UI via nginx
+
+```shell
+$ kubectl port-forward service/lab-nginx 8443:443
+Forwarding from 127.0.0.1:8443 -> 443
+Forwarding from [::1]:8443 -> 443
+```
+Now you can go to https://localhost:8443 to access Egeria UI.
+
+## Starting over
+
+Because the environment is entirely self-contained, you can easily start over the labs simply
+by deleting the deployment and running the installation again. This will wipe out all of the
+metadata across the lab Egeria servers, remove all messages from the Kafka bus used in the cohort,
+reset the Jupyter notebooks to their original clean state, etc.
+
+To delete the deployment, simply run this:
+
+```bash
+$ helm delete lab
+```
+
+Where `lab` is the name you used in your original deployment. (You can see what it's called by first running `helm list` and reviewing the output.)
+
+(Then just re-run the last command in the Installation section above to get a fresh environment.)
+
+## Overriding Configuration
+
+The chart is configured to use a default set of parameters.  You can override these by creating a file such as `lab.yaml` with the  contents of any values you wish to modify, for example:
+
+```
+service:
+  type: NodePort
+  nodeport:
+    jupyter: 30888
+    core: 30080
+    datalake: 30081
+    dev: 30082
+    factory: 30083
+    ui: 30443
+```
+
+Refer to the existing values file for additional ports in this section that may reflect new components as added
+
+You can then deploy using
+`helm install lab odpi-egeria-lab -f lab.yaml` which will override standard defaults with your choices
+
+## Enabling persistence
+
+Support has been added to use persistence in these charts. See 'values.yaml' for more information on this option.
+You may also wish to refer to the 'egeria-base' helm chart which is a deployment of a single, persistent, autostart server with UI.
+
+Note however that since this will save the state of your configuration done from
+the tutorial notebooks it may be confusing - as such this is disabled by default. It may be useful if you are modifying the charts for your own use.
+
+You will also need to delete all storage associated with the chart manually if you want to cleanup/reset - for example
+```bash
+kubectl delete pvc --all
+kubectl delete pv --all
+```
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/container-images.md
+++ b/site/docs/guides/admin/kubernetes/container-images.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# Container Images
+
+
+This section will list the current images we produce for Egeria to aid those who wish to setup their own container-based deployment of Egeria.
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/custom_deployment.md
+++ b/site/docs/guides/admin/kubernetes/custom_deployment.md
@@ -1,0 +1,9 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Creating your own Helm chart and deployment
+
+This section will add useful tips on extending the provided charts
+to deploy Egeria in your own environment.
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/helm.md
+++ b/site/docs/guides/admin/kubernetes/helm.md
@@ -1,0 +1,81 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Helm
+
+_Helm is the best way to find, share, and use software built for Kubernetes._ - https://helm.sh
+
+## Deploying apps in Kubernetes
+
+In Kubernetes, resources such as pods (to run code) or services (for network accessibility) are defined in yaml. One or more documents can be submitted at a time.
+
+So we might have one yaml file that defines our pod - with information about which container images to run, and another to setup a network service. finally we may have another that describes our storage requirements (a persistent volume claim
+)
+
+## What does Helm do?
+
+Helm provides a way of bunding yaml files together into an archive, together with a templating mechanism to allow reuse of common patterns & ensure different yamls are consistent and can reference each other.
+
+These archives are known as 'Charts' and can be hosted in a known format as a 'chart repository'. The archives are versioned.
+
+Helm is basically focussed on creating yaml documents that are submitted to Kubernetes - it is not involved in the runtime of a Kubernetes environment. Once a helm app is installed, interaction is just with the regular kubernetes objects.
+
+[Helm Commands](https://helm.sh/docs/helm/helm/) include options to
+* install
+* uninstall
+* list
+* search
+* upgrade
+* rollback
+
+## helm under microk8s
+
+microk8s qualifies the Helm command `helm` in that you need to use `microk8s helm3` so either
+* When docs refer you to type `helm` then just use `microk8s helm3`
+* add a shell alias ie `alias helm='microk8s helm3'` into ~/.zshrc or equivilent shell startup script - if this doesn't clash with your other usage of k8s.
+
+If using this approach you not need to explicitly install Helm.
+
+## Installing Helm
+
+Some Kubernetes environments may install helm as part of their client tooling, refer to the docs to see if this is the case, and run `helm version` to check - expect to use v3 or above. If so, install can be skipped.
+
+### MacOS
+
+If using macOS with HomeBrew installed, helm can be simply installed with
+```shell
+brew install helm
+```
+
+### Other platforms (Linux, Windows)
+
+See the [Installation Guide](https://helm.sh/docs/intro/install/) for more ways to install Helm
+
+## Accessing the egeria charts repository
+
+Our helm charts for Egeria are stored in a repository hosted on GitHub. The source for these is at https://github.com/odpi/egeria-charts , and as charts are updated they are automatically published to a GitHub pages Website (in fact this one!)
+
+Run the following to add this repository
+```shell
+helm repo add egeria https://odpi.github.io/egeria-charts
+```
+
+Before searching or installing, always update your local copy of the repository
+```shell
+helm repo update egeria
+```
+You can now list released charts:
+```shell
+helm search repo egeria
+```
+
+or development charts (being worked on, or using code from master)
+```shell
+helm search repo egeria --devel
+```
+and install a chart that looks interesting - 
+```shell
+helm install egeria/<chart>
+```
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/intro.md
+++ b/site/docs/guides/admin/kubernetes/intro.md
@@ -1,0 +1,23 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Egeria & Kubernetes
+
+Kubernetes offers one standard way of deploying the Egeria platform into a variety of environments including a developer desktop, or a public cloud environment:
+
+* [Introduction to Kubernetes](k8s.md)
+ 
+* [Introduction to Helm](helm.md)
+ 
+* [Sample chart - the Coco Pharmaceuticals lab](chart_lab.md)
+
+* [Sample chart - base egeria setup](chart_base.md)
+
+* [Container images](container-images.md)
+
+* [Developing a custom deployment](custom_deployment.md)
+
+* [Egeria Operator](operator.md)
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/k8s.md
+++ b/site/docs/guides/admin/kubernetes/k8s.md
@@ -1,0 +1,191 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# What is Kubernetes?
+
+_Kubernetes, also known as K8s, is an open-source system for automating deployment, scaling, and management of containerized applications._ - https://kubernetes.io
+
+This is how the [official website](https://kubernetes.io/) [describes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) it. It's effectively a standardized way of deploying applications in a very scalable way - from everything such as development prototyping through to massive highly available enterprise solutions.
+
+In this document I'll give a very brief summary that should help those of you new to Kubernetes to make your first steps with Egeria.
+
+# What are the key concepts in Kubernetes?
+
+These are just some of the concepts that can help to understand what's going on. This isn't a complete list.
+
+## Api
+
+Kubernetes using a standard [API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/) which is oriented around manipulating Objects. The commands are therefore very standard, it's all about the objects.
+
+
+
+## Making it so
+The system is always observing the state of the system through these objects, and where there are discrepancies, taking action to 'Make it So' as Captain Picard would say. The approach is imperitive. So we think of these [objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) as describing the _desired state_ of the system.
+
+## Namespace
+
+A [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) provides a way of seperating out kubernetes resources by users or applications as a convenience. It keeps names more understandable, and avoids global duplicates.
+
+For example a developer working on a k8s cluster may have a namespace of their own to experiment in.
+
+## Container
+
+A [Container](https://kubernetes.io/docs/concepts/containers/) is what runs stuff. It's similar to a Virtual Machine in some ways, but much more lightweight. Containers use code Images which may be custom built, or very standard off-the-shelf reusable items. Containers are typically very focussed on a single need or application. 
+
+## Pod
+
+A [Pod](https://kubernetes.io/docs/concepts/workloads/pods/) is a single group of one or more containers. Typically a single main container runs in a pod, but this may be supported by additional containers for log, audit, security, initialization etc. Think of this as an atomic unit that can run a workload.
+
+Pods are disposeable - they will come and go. Other objects are concerned with providing a reliable service.
+
+## Service
+
+A [service](https://kubernetes.io/docs/concepts/services-networking/service/) provides network accessibility to one or more pods. The service name will be added into local Domain Name Service (DNS) for easy accessibility from other pods. Load can be shared across multiple pods
+
+## Ingres
+
+Think of [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)  as the entry point to Kubernetes services from an external network perspective - so it is these addresses external users would be aware of.
+
+## Deployment 
+
+A [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) keeps a set of pods running - including replica copies, ie restarted if stopped, matching resource requirements, handling node failure .
+
+## Stateful Set
+
+A [stateful set](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) goes further than a deployment in that it keeps a well known identifier for each identical replica. This helps in allocating persistent storage & network resources to a replica
+
+## ConfigMap
+
+A [config map](https://kubernetes.io/docs/concepts/configuration/configmap/) is a way of keeping configuration (exposed as files or environment variables) seperate to an application.
+
+## Secret
+
+A [secret](https://kubernetes.io/docs/concepts/configuration/secret/) is used to keep information secret, as the name might suggest ... This might be a password or an API key & the data is encrypted
+
+## Custom Objects
+
+In addition to this list -- and many more covered in the official documentation -- Kubernetes also supports custom resources. These form a key part of Kubernetes [Operators](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). 
+
+## Storage
+
+Pods can request storage - which is known as a persistent volume claim (PVC), which are either manually or automatically resolved to a persistent volume.
+
+See the k8s docs [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+
+
+# Why are we using Kubernetes?
+
+ All sizes of systems can run kubernetes applications - from a small raspberry pi through desktops and workstations through to huge cloud deployments. 
+
+Whilst the details around storage, security, networking etc do vary by implementation, the core concepts, and configurations work across all.
+
+Some may be more concerned about an easy way to play with development code, try out new ideas, whilst at the far end of the spectrum enterprises want something super scalable and reliable, and easy to monitor.
+
+For egeria we want to achieve two main things
+* Provide easy to use demos and tutorials that show how Egeria can be used and worked with without requiring too much complex setup. 
+* Provide examples that show how Egeria can be deployed in k8s, and then adapted for the organization's needs.
+
+Other alternatives that might come to mind include
+ * Docker -- whilst simple, this is more geared around running a single container, and building complex environment means a lot of work combining application stacks together, often resulting in something that isn't usable. We do of course still have container images, which are essential to k8s, but these are simple & self contained.
+ * docker-compose -- this builds on docker in allowing multiple containers and servers to be orchestrated, but it's much less flexible & scalable than kubernetes.
+
+# How do I get access to Kubernetes?
+
+[Getting Started](https://kubernetes.io/docs/setup/) provides links to setting up Kubernetes in many environments. Below we'll take a quick look at some of the simpler examples, especially for new users.
+
+## microk8s (Linux, Windows, macOS)
+
+**[Official microk8s site](https://microk8s.io)**
+
+4GB is recommended as a minimum memory requirement.
+
+As with most k8s implementations, when running some ongoing cpu will be used, so if running on your laptop/low power device it's recommended to refer to the relevant docs & stop k8s when not in use.
+
+When running on a separate server or a cloud service this isn't a concern.
+
+When using microk8s, note that the standard k8s commands are renamed to avoid clashes, so use the microk8s ones in the remainder of the Egeria documentation
+
+kubectl -> microk8s kubectl
+helm -> microk8s helm
+
+They can also be aliased on some platforms.
+
+### MacOS
+The [macos install](https://microk8s.io/#tab-three__content) docs cover the steps needed to install microk8s.
+
+Most of the Egeria development team use MacOS, so the instructions are elaborated and qualified here:
+
+* The recommended approach uses [HomeBrew](https://brew.sh). This offers a suite of tools often found on linux which are easy to setup on macOS. See [install docs](https://docs.brew.sh/Installation)
+* IMPORTANT: Before installing, go into System Preferences->Security & Privacy. Click the lock to get into Admin mode. Then ensure Firewall Options->Enable Stealth Mode is NOT enabled (no tick). **If it is, microk8s will not work properly**. [More](https://github.com/ubuntu/microk8s/issues/2509)
+* If you are concerned over the firewall change, or homebrew requirement, refer back to the official k8s documentation & choose another k8s implementation that works for you.
+* Ensure you turn on the following services: storage, dns, helm3 . 
+* dashboard is also useful to understand more about k8s and what is running. However it is currently failing as described in [issue 2507](https://github.com/ubuntu/microk8s/issues/2507)
+
+As an example, the following commands should get you set up, but always check the official docs for current details
+
+```shell
+brew install ubuntu/microk8s/microk8s
+microk8s install
+microk8s status --wait-ready
+microk8s enable dns storage helm3
+microk8s kubectl get all --all-namespaces
+```
+Kubernetes is now running.
+
+### Windows
+
+Follow the [official instructions](https://microk8s.io/#tab-two__content) (untested)
+
+### Linux
+
+Follow the [official instructions](https://microk8s.io/#tab-one__content) (untested)
+
+### kubectl command under microk8s
+
+microk8s qualifies the core k8s command `kubectl` in that you need to use `microk8s kubectl` so either
+* When docs refer you to type `kubectl` then just use `microk8s kubectl`
+* add a shell alias ie `alias kubectl='microk8s kubectl'` into ~/.zshrc or equivilent shell startup script
+
+
+## Docker Desktop (Windows, macOS)
+
+[Docker Desktop](https://www.docker.com/products/docker-desktop) supports Kubernetes
+
+After installing, go into Docker Desktop 'settings and select 'Kubernetes'. Make sure 'Enable Kubernetes' is checked. Also under resources ensure at least 4GB is allocated to Docker
+
+## Cloud
+
+Many cloud providers offer Kubernetes deployments which can be used for experimentation or production. This include
+
+* [Redhat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift/try-it) on multiple cloud providers including on [IBMCloud](https://www.ibm.com/uk-en/cloud/openshift)
+* [Kubernetes on IBMCloud](https://www.ibm.com/cloud/kubernetes-service?p1=Search&p4=43700058232060428&p5=e&gclid=*&gclsrc=aw.ds)
+* [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/)
+* [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) (GKE)
+
+In addition to a cloud install, ensure you have installed the relevant cloud provider's tooling to manage their k8s environment, including having access to the standard kubernetes command `kubectl`.
+
+Note that in the team's testing we mostly are running Redhat OpenShift on IBMCloud as a managed service. We welcome feedback of running our examples on other environments, especially as some of the specifics around ingress rules, storage, security can vary.
+
+## Accessing applications in your cluster
+
+See also [kubernetes docs](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/)
+
+### NodePort
+
+In the sample charts provided an option to use a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) is usually provided.
+
+This is often easiest when running k8s locally, as any of the ip addressible worker nodes in your cluster can service a request on the port provided. This is why it's named a 'node port' ie a port on your node..
+
+### kubectl port-forward
+
+This can be run at a command line, and directly sets up forwarding from local ports into services running in your cluster. It requires no additional configuration beforehand, and lasts only as long as the port forwarding is running.
+
+See [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) for more info
+
+### Ingress
+
+Ingress rules define how traffic directed at your k8s cluster is directed. Their definition tends to vary substantially between different k8s implementations but often is the easiest approach when running with a cloud service.
+
+* [microk8s ingress](https://microk8s.io/docs/addon-ingress) 
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/admin/kubernetes/operator.md
+++ b/site/docs/guides/admin/kubernetes/operator.md
@@ -1,0 +1,214 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# What is an Operator?
+
+- An operator is a way of extending [Kubernetes](k8s.md) with application specific capababilities. 
+- The notion of 'operator' comes from managing an application through it's lifecycle, just as a human operator would, but here we do it automatically.
+
+Operator functionality could include:
+ - deploying an application
+ - upgrading an applications, perhaps migrating data
+ - taking backups
+ - mapping application specific behaviour into more standard kubernetes commands
+
+A summary of some interesting operators can be found [here](https://github.com/odpi/egeria-k8s-operator/blob/master/doc/research/PopularOperatorCapabilities.md)
+ 
+## Custom Resources
+
+Kubernetes has many standard resource definitions, such as for pods, services, deployments. Instances of each define the intended state of the object it represents.
+
+[Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-resources) Definitions (**CRD**s) extend Kubernetes to allow anything to be represented, such as the intended state of an application stack.  They are defined in yaml. 
+
+Resource definitions include:
+ - apiVersion - consider this the namespace
+ - metadata - useful for searching, selecting
+ - spec - the intended state we are describing
+ - status - used to capture current state
+ 
+An instance of a CRD is known as a Custom Resource (**CR**)
+
+## Controller
+
+There is no intrinsic behaviour associated with a custom resource - it is purely a document with a defined schema. The behaviour is defined by the [Controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers), which is code running within the Kubernetes cluster.
+
+The controller's objective is to make reality match the configured Custom Resource. It will watch particular resource types - the primary being the CRD above - and as changes are observed will do whatever is needed to configure application to match the desired intent. It is primarily a reconcilation loop.
+
+The controller will likely use a combination of Kubernetes APIs, perhaps defining and updating other resources, as well as interacting directly with application code within, or external to the cluster.
+
+## Further information
+* [Operator Pattern (Docs, kubernetes.io)](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+* Kubernetes Operator 101 (Blog, Red Hat) - [Part1](https://developers.redhat.com/articles/2021/06/11/kubernetes-operators-101-part-1-overview-and-key-features) | [Part2](https://developers.redhat.com/articles/2021/06/22/kubernetes-operators-101-part-2-how-operators-work#)
+* [Kubernetes Operator (Video, IBM)](https://www.youtube.com/watch?v=i9V4oCa5f9I)
+* [Operators over easy: an introduction to Kubernetes Operators (Video, Red Hat)](https://www.redhat.com/en/blog/operators-over-easy-introduction-kubernetes-operators)
+
+# How does it differ from Helm?
+
+[Helm](helm.md) is a popular way of installing an application stack through charts, and sometimes upgrading. However at it's core, Helm is a templating engine. It takes templates, runs them through a processor to expand variables (across multiple documents). It then submits the documents to the Kubernetes API server just the same as if they'd be created standalone.
+
+Helm charts can be stored in a repository, and make putting together a complex stack relatively easy. (we already use them successfully for Egeria). More complex behaviour can be done by deploying additional containers, jobs etc.
+
+This is **very** different to an operator. Rather than create standard Kubernetes resources, with an operator we are trying to model our application, define it's intended state, and then have active code **always** running to monitor and achieve this. Operators are thus much more sophisticated, but also complex.
+
+Operators and custom resources can themselves be deployed using Helm - so we don't think of the Operators are replacing Helm, rather they are very complementary techniques which can be used together. For example, whist an operator might focus on a single application, a helm chart may deploy a demonstation environment.
+
+# Operator Lifecycle Manager
+
+The [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) (**OLM**) is an optional extension that can be used alongside operators to manage them. OLM allows for operator discovery and manages dependencies between operators.
+
+OLM is [standard in Red Hat OpenShift](https://docs.openshift.com/container-platform/4.8/operators/understanding/olm/olm-understanding-olm.html)
+
+**OLM is not necessary to use operators** - and unlike operators themselves, the framework **is not present in all Kubernetes distibutions**.
+
+# Catalogs
+
+A catalog of operators can be found on [OperatorHub](https://operatorhub.io) and authors can [submit their own operator](https://operatorhub.io/contribute) to help with findability.
+
+# Building an operator
+
+Operators can be built in any language than can support making API calls to Kubernetes. For example it would be possible to write a Java based operator. This is complex, and uses low level APIs, with few examples published. 
+
+The [Operator Framework](https://operatorframework.io) is a toolkit to make it easier to develop an operator by including higher level APIs, and tools for code generation. It supports:
+* [Helm](https://helm.sh) - this wraps up a Helm chart as an operator, but as such it only delivers install/upgrade capability. They can be managed and catalogued as an operator.
+* [Ansible](https://www.ansible.com) - an ansible operator can respond to events & run ansible scripts accordingly. This makes them significantly more flexible
+* [Go](https://www.golangprograms.com) - These are full 'native' operators with full access to the Kubernetes API. Kubernetes itself is written in Go. They are therefore very flexible, though more complex to develop. They do however represent the majority of development in this area, providing also the best scope for help from peers.
+
+A more detailed comparison can be found in this [blog](https://cloud.redhat.com/blog/build-your-kubernetes-operator-with-the-right-tool)
+
+For another project aiming to support java see https://github.com/java-operator-sdk/java-operator-sdk
+
+Egeria is implementing a Go operator, using the Operator Framework. This is the most established & flexible approach.
+
+# Egeria Operator Development
+
+The Egeria operator is being developed at https://github.com/odpi/egeria-k8s-operator - see here for
+* [Issues](https://github.com/odpi/egeria-k8s-operator)
+* prereqs/dependencies
+* feedback, getting involved
+* build, install, and usage instructions
+
+## Design considerations
+
+### Egeria configurations
+
+Custom Resource definitions allow for a very detailed specification of what we want our Egeria deployment to be. However Egeria itself already has a sophisticated approach to configuration - some elements of which are still evolving.
+
+It could be possible to try and fully expose this configuration as a CRD. However due to the complexity, fluidity, and duplication the Operator instead will add k8s deployment specific information around existing Egeria configurations.
+
+It's therefore imperative we keep the **Authoring** of server configuration distinct from **Deployment**. The deployment environment will be different in a Kubernetes environment (hostnames, service names etc)
+
+Initially the egeria config document will be used verbatim, however if processing is needed, a [Admission Webhook](https://sdk.operatorframework.io/docs/building-operators/golang/webhook/) could be used to validate ([validating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook)) & convert ([mutating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook)) the config before storing in k8s. This approach could also be used for CR validation.
+
+[Example server configuration documents](https://github.com/odpi/egeria-k8s-operator/tree/master/samples/server)
+
+
+### Scaling & failover
+
+Kubernetes is a useful container solution that scales from a raspberry pi to huge cloud deployments. As such it may be used for anything from development to full enterprise production - and this is a strong part of it's appeal. So the operator must support everything from a small development environment, through to a scalable, reliable cloud environment. 
+
+#### Egeria Platform
+
+The [OMAG server platform](https://odpi.github.io/egeria-docs/introduction/overview/#omag-server-platform) (aka 'server chassis') is effectively a java process that is launched and acts as a container for
+running Egeria servers (below). In itself it has relatively little configuration but does include
+- TLS configuration ie passwords, keys, certs
+- Spring configuration (security, plugins)
+
+It offers an admin interface for defining servers (below) and starting/stopping them. It also provides the base URL which is extended for server access.
+
+The platform's connectors are mostly limited to configuration & security.
+
+#### Egeria Servers
+
+The [OMAG Server](https://odpi.github.io/egeria-docs/introduction/overview/#omag-servers) comes in a number of
+different forms including a repository proxy, a metadata repository, a view server etc
+
+A 'server' is a logical concept that actually executes code within an Egeria Platform but is basically what is defined, started, stopped,
+and also hosts the myriad of REST APIs that egeria supports such as for creating the definition of a data asset.
+
+#### So how do we scale?
+
+Three main options are:
+
+ * Model both servers & platforms as different Kubernetes resources. This provides the most accurate mapping, but would require the operator to manage 'scheduling' servers on platforms, and allowing for this to change dynamically as workload & requiremenets change. This would also require having logical URLs unique to each server.
+ * Define servers, and automatically create platforms as needed, resulting in a 1:1 relationship between server and platform. This is simple, though server configuration would need to be overloaded with platform configuration (like ssl keys). This would also lead to creating many more platforms which comes at a resource cost (ram, cpu), as this is a process. Servers however are just logical constructs and have minimal overhead.
+ * Handle replication at the level of platform only. This is close to how Kubernetes works with most apps. 
+
+Whilst initially persuing the first option, due to complexity, the last of these has now been chosen for simplicity.
+
+This has also resulted in the Egeria Platform being the first-class resource we focus on defining for the operator, at least initially. 
+
+### Stateful set vs Deployment 
+
+A Deployment manages scaling of a set of containers (such as egeria platform) across multiple pods. A Statefulset extends this to provide a unique identity which can be used for unique service definitions, or for maintaining an association with dedicated storage.
+
+In the current Egeria helm chart we use a stateful set that that persistent storage can be allocated uniquely to each
+pod & retained across restarts.
+
+However the assumption in the operator environment is that Egeria is stateless (beyond the config & CR), and that any persistent state is managed
+via the connections to metadata storage etc, and that a unique service address is not needed. This latter point may need to be revisited if the Egeria operator needs to actively interact with the individual replicas for control/config, but this is not yet the case, hence the choice of a simpler deployment initially.
+
+### Configuration updates
+
+
+* If a server config document is changed the initially the platform will be restarted. 
+* Later we will try to just restart/stop the modified server and/or perform a rolling change. Care will need to be taken if the config change leads to a conflict.
+
+### Admin requests
+
+* The operator has no knowledge of the state of egeria servers, discovery engines etc.
+* Attempts to perform any admin ops should be blocked (via security plugins to both platform & server)
+* To refine this will require modeling those concepts in the operator
+
+### Metadata repositories
+
+The only metadata repository that offers a suitable HA/remote environment &  supported by the Egeria open source project is [XTDB :material-dock-window:](https://xtdb.com){ target=xtdb }, using the [Egeria XTDB connector](/egeria-docs/connectors/xtdb). 
+
+Note: At this point, the deployment of XTDB itself is outside the scope of the operator.
+
+### Connectors
+
+Much of the capability in Egeria is pluggable. For example we have a connector to the message bus, which could be kafka, but equally
+may be RabbitMQ (if a connector were written). We have connectors that understand data sources such as for Postgres. These are
+implemented as java jars, and are added into the classpath of the egeria platform. Thus the platform can provide a certain capability
+with these additional connectors, but it is the server which defines which ones to use (and refers to the class name to locate)
+
+An Egeria server configuration document therefore contains many references to connectors. The references libraries must be available in the runtime environment ie platform. This is done by ensuring they are pointed to within the spring loader's 'LOADER_PATH' environment variable.
+
+Several approaches are possible:
+* Build a custom container image based on the [Egeria docker image](https://github.com/odpi/egeria/tree/master/open-metadata-resources/open-metadata-deployment/docker/egeria) including the desired connectors, and either placing the required additional files into /deployments/server/lib, or placing them elsewhere in the image and ensuring LOADER_PATH is set
+* Dynamically download or mount the required libraries - and dependencies - when the server platform is set up by the operator, for example through an init job.
+
+Currently the operator takes the former, simpler approach. Therefore specifying a custom container image as part of the platform configuration will often be required.
+
+Connectors also often tend to refer to endpoints - for example the location of a Kafka message bus, a server's own address. Currently the server configuration document
+passed to the operator must have correct addresses. As yet there is no manipulation or templating of these addresses, though this may change in future.
+
+## Operator Development
+
+### Prerelease 
+ - deploy Egeria platforms with a list of servers
+ - uses Kubernetes [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) to store individual server configuration
+ - requires the user to use repositories capable of supporting replication (like XTDB)
+
+### Still to do for an initial release
+ - Helm chart to deploy a complete demo environment (coco pharma) with Egeria operator & XTDB backend.
+ - working through the full server authoring lifecycle (alongside Server Author UI & View Services) - including templating of connections which contain host:ip from the authoring environment
+ - Evaluating alternative stores of server configuration (at a minimum may need to be a [secret](https://kubernetes.io/docs/concepts/configuration/secret/) as we include auth info - but decided to use ConfigMaps initially for clarity during initial design)
+ - Automated testing & packaging (to both a full k8s cluster & using a test framework)
+ - Further end-user docs on using the operator
+ - publish on [Operator Hub](https://operatorhub.io)
+
+
+### Future enhancements
+ - [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) integration
+ - publish on [Operator Hub](https://operatorhub.io)
+ - refinement of configurations (consolidation, admission webhooks)
+ - consideration of more detailed mapping between Egeria Concepts and operator
+ - rolling platform restart (config update, upgrade etc)
+ - Handling upgrades/migration between egeria versions
+ - Integration with [Prometheus](https://prometheus.io)
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/chart_base.md
+++ b/site/docs/guides/operations/kubernetes/chart_base.md
@@ -1,0 +1,199 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Base Egeria (egeria-base)
+
+This is a simple deployment of Egeria which will just deploy a basic Egeria environment
+which is ready for you to experiment with. Specifically it sets up
+
+- A single egeria platform which hosts
+    - An egeria metadata server with a persistent graph store
+    - A new server to support the UI
+- A UI to allow browsing of types, instances & servers
+- Apache Kafka & Zookeeper
+
+It does not provide access to our lab notebooks, the Polymer based UI, nor is it preloaded with any data.
+
+This chart may also be useful to understand how to deploy Egeria within kubernetes. In future we anticipate providing
+an [operator](https://github.com/odpi/egeria-k8s-operator) which will be more flexible
+
+## Prerequisites
+
+In order to use the labs, you'll first need to have the following installed:
+
+- A Kubernetes cluster at 1.15 or above
+- the `kubectl` tool in your path
+- [Helm](https://github.com/helm/helm/releases) 3.0 or above
+
+No configuration of the chart is required to use defaults, but information is provided below
+
+## Installation
+
+From one directory level above the location of this README, run the following:
+
+```bash
+helm dep update egeria-base
+helm install egeria egeria-base
+```
+
+THE INSTALL WILL TAKE SEVERAL MINUTES
+
+This is because it is not only creating the required
+objects in Kubernetes to run the platforms, but also is configuring egeria itself - which involves waiting
+for everything to startup before configuring Egeria via REST API calls.
+
+Once installed the configured server is set to start automatically, storage is persisted, and so if your pod gets moved/restarted, egeria should come back automatically with the same data as before.
+
+### Additional Install Configuration
+
+This section is optional - skip over if you're happy with defaults - a good idea to begin with.
+
+In a helm chart the configuration that has been externalised by the chart writer is specified in the `values.yaml` file which you can find in this directory. However rather than edit this file directly, it's recommended you create an additional file with the required overrides.
+
+As an example, in `values.yaml` we see a value 'serverName' which is set to mds1. If I want to override this I could do
+```bash
+helm install --set-string egeria.serverName=myserver
+```
+However this can get tedious with multiple values to override, and you need to know the correct types to use.
+
+Instead it may be easier to create an additional file. For example let's create a file in my home directory `~/egeria.yaml` containing:
+```
+egeria:
+  serverName: metadataserver
+  viewServerName: presentationview
+```
+We can then install the chart with:
+```bash
+helm install -f ~/egeria.yaml egeria egeria-base
+```
+
+Up to now the installation has been called `egeria` but we could call it something else ie `metadataserver`
+```bash
+helm install -f ~/egeria.yaml metadataserver egeria-base
+```
+
+This is known as a `release` in Helm, and we can have multiple installed currently.
+
+To list these use
+```bash
+helm list
+```
+and to delete both names we've experimented with so far:
+```bash
+helm delete metadataserver
+helm delete egeria
+```
+
+Refer to the comments in `values.yaml` for further information on what can be configured - this includes:
+- server, organization, cohort names
+- storage options - k8s storage class/size
+- Egeria version
+- Kubernetes service setup (see below also)
+- roles & accounts
+- timeouts
+- names & repositories for docker images used by the chart
+- Kafka specific configuration (setup in the Bitnami chart we use)
+
+### Using additional connectors
+
+If you have additional Egeria connectors that are needed in your deployment, you should soon be able to include the following when deploying the chart
+
+```bash
+helm install --include-dir libs=~/libs egeria egeria-base
+```
+Where in this example ~/libs is the directory including the additional connectors you wish to use.
+
+However the support for this is awaiting a [helm PR](https://github.com/helm/helm/pull/8841), so in the meantime please copy files directly into a 'libs' directory within the chart instead.
+
+For example
+```bash
+mkdir egeria-base/libs
+cp ~/libs/*jar egeria-base/libs
+```
+
+These files will be copied into a kubernetes config map, which is then made available as a mounted volume to the runtime image of egeria & added to the class loading path as `/extlib`. You still need to configure the egeria server(s) appropriately
+## Accessing Egeria
+
+When this chart is installed, an initialization job is run to configure the egeria metadata server and UI.
+
+For example looking at kubernetes jobs will show something like:
+```bash
+$ kubectl get pods                                                                                      [17:27:11]
+NAME                                        READY   STATUS    RESTARTS   AGE
+egeria-base-config-crhrv                    1/1     Running   0          4m16s
+egeria-base-platform-0                      1/1     Running   0          4m16s
+egeria-base-presentation-699669cfd4-9swjb   1/1     Running   0          4m16s
+egeria-kafka-0                              1/1     Running   2          4m16s
+egeria-zookeeper-0                          1/1     Running   0          4m16s
+```
+
+You should wait until that first 'egeria-base-config' job completes, it will then disappear from the list.
+This job issues REST calls against the egeria serves to configure them for this simple environment (see scripts directory).
+
+The script will not run again, since we will have now configured the servers with persistent storage, and for the platform
+to autostart our servers. So even if a pod is removed and restarted, the egeria platform and servers should return in the same state.
+
+We now have egeria running within a Kubernetes cluster, but by default no services are exposed externally - they are all of type `ClusterIP` - we can see these with
+
+```bash
+$ kubectl get services                                                                                                                                                                                                                                [12:38:16]
+NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP                         PORT(S)                      AGE
+egeria-kafka                ClusterIP      172.21.42.105    <none>                              9092/TCP                     33m
+egeria-kafka-headless       ClusterIP      None             <none>                              9092/TCP,9093/TCP            33m
+egeria-platform             ClusterIP      172.21.40.79     <none>                              9443/TCP                     33m
+egeria-presentation         ClusterIP      172.21.107.242   <none>                              8091/TCP                     33m
+egeria-zookeeper            ClusterIP      172.21.126.56    <none>                              2181/TCP,2888/TCP,3888/TCP   33m
+egeria-zookeeper-headless   ClusterIP      None             <none>                              2181/TCP,2888/TCP,3888/TCP   33m
+```
+
+The `egeria-presentation` service is very useful to expose as this provides a useful UI where you can explore
+types and instances. Also `egeria-platform` is the service for egeria itself. In production you might want this only exposed very carefully to other systems - and not other users or the internet, but for experimenting with egeria let's assume you do.
+
+How these are exposed can be somewhat dependent on the specific kubernetes environment you are using.
+
+In the [lab chart](chart_lab.md) we provided an example of using `kubectl port-forward`. Here we use RedHat OpenShift in IBM Cloud, where you can expose these services via a LoadBalancer using
+
+```
+kubectl expose service/egeria-presentation --type=LoadBalancer --port=8091 --target-port=8091 --name pres  
+kubectl expose service/egeria-platform --type=LoadBalancer --port=9443 --target-port=9443 --name platform   
+```
+
+If I run these, and then look again at my services I see I now have 2 additional entries (modified for obfuscation):
+```
+platform                    LoadBalancer   172.21.218.241   3bc644c3-eu-gb.lb.appdomain.cloud   9443:30640/TCP               25h
+pres                        LoadBalancer   172.21.18.10     42b0c7f5-eu-gb.lb.appdomain.cloud   8091:30311/TCP               22h
+```
+
+So I can access them at their respective hosts. Note that where hosts are allocated dynamically, it can take up to an hour or more for DNS caches to refresh. Waiting up to 5 minutes then refreshing a local cache has proven sufficient for me, but your experience may differ.
+
+In the example above, the Egeria UI can be accessed at `https://42b0c7f5-eu-gb.lb.appdomain.cloud:8091/org/` . Replace the hostname accordingly, and also the `org` is the organization name from the `Values.yaml` file we referred to above
+
+Once logged in, you should be able to login using our demo userid/password of `garygeeke/admin` & start browsing types and instances within Egeria.
+
+You can also issue REST API calls against egeria using a base URL for the platform of `https://3bc644c3-eu-gb.lb.appdomain.cloud` - Other material
+covers these REST API calls in more detail, but a simple api doc is available at `https://3bc644c3-eu-gb.lb.appdomain.cloud/swagger-ui.html`
+## Cleaning up / removing Egeria
+
+To delete the deployment, simply run this for Helm3:
+
+```bash
+$ helm delete egeria
+```
+
+In addition, the egeria chart makes use of persistent storage. To remove these use
+```bash
+$ kubectl get pvc
+NAME                                        STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                 AGE
+data-egeria-kafka-0                         Bound    pvc-d31e0012-8568-4e6f-ae5d-94832ebcd92d   10Gi       RWO            ibmc-vpc-block-10iops-tier   48m
+data-egeria-zookeeper-0                     Bound    pvc-90739fce-dce0-422b-8738-a38293d8fdfb   10Gi       RWO            ibmc-vpc-block-10iops-tier   48m
+egeria-egeria-data-egeria-base-platform-0   Bound    pvc-197ba47e-a6d5-4f35-a7d8-7b7ec1ed1df3   10Gi       RWO            ibmc-vpc-block-10iops-tier   48m
+```
+Identify those associated with egeria - which should be obvious from the name and then delete with
+```bash
+kubectl delete pvc <id>
+```
+
+See the section on Configuration for more details
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/chart_lab.md
+++ b/site/docs/guides/operations/kubernetes/chart_lab.md
@@ -1,0 +1,204 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# Lab - Coco Pharmaceuticals (odpi-egeria-lab)
+
+This example is intended to replicate the metadata landscape of a hypothetical company, Coco Pharmaceuticals, and allow you to understand a little more about how Egeria can help, and how to use it. This forms our 'Hands on Lab'.
+
+The Helm chart will deploy the following components, all in a self-contained environment,
+ allowing you to explore Egeria and its concepts safely
+and repeatably:
+
+- Multiple Egeria servers
+- Apache Kafka (and its Zookeeper dependency)
+- Example Jupyter Notebooks
+- Jupyter runtime
+- Egeria's React based UI
+
+## Prerequisites
+
+In order to use the labs, you'll first need to have the following installed:
+
+- Kubernetes 1.15 or above
+- Helm 3.0 or above
+- Egeria chart repository configured & updated
+
+6GB RAM minimum is recommended for your k8s environment.
+
+You no longer need a git clone of this repository to install the chart.
+
+## Installation
+
+```bash
+helm install lab egeria/odpi-egeria-lab
+```
+
+In the following examples we're using microk8s.
+
+```bash
+$ helm install lab egeria/odpi-egeria-lab                                                                            [11:47:04]
+WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /var/snap/microk8s/2346/credentials/client.config
+NAME: lab
+LAST DEPLOYED: Tue Aug 10 11:47:19 2021
+NAMESPACE: default
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+ODPi Egeria lab tutorial
+---
+```
+Some additional help text is also output, which is truncated for brevity.
+
+It can take a few seconds for the various components to all spin-up. You can monitor
+the readiness by running `kubectl get all` -- when ready, you should see output like the following:
+
+```bash
+$ kubectl get all                                                                                                     [13:53:43]
+NAME                                                   READY   STATUS    RESTARTS   AGE
+pod/lab-odpi-egeria-lab-ui-74cc464575-cf8rm            1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-datalake-0                     1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-nginx-7b96949b4f-7dff4         1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-presentation-bd9789747-rbv69   1/1     Running   0          126m
+pod/lab-kafka-0                                        1/1     Running   0          126m
+pod/lab-zookeeper-0                                    1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-dev-0                          1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-uistatic-7b98d4bf9b-sf9bj      1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-core-0                         1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-factory-0                      1/1     Running   0          126m
+pod/lab-odpi-egeria-lab-jupyter-77b6868c4-9hnlp        1/1     Running   0          126m
+
+NAME                                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
+service/kubernetes                    ClusterIP   10.152.183.1     <none>        443/TCP                      20h
+service/lab-kafka-headless            ClusterIP   None             <none>        9092/TCP,9093/TCP            126m
+service/lab-zookeeper-headless        ClusterIP   None             <none>        2181/TCP,2888/TCP,3888/TCP   126m
+service/lab-zookeeper                 ClusterIP   10.152.183.25    <none>        2181/TCP,2888/TCP,3888/TCP   126m
+service/lab-jupyter                   ClusterIP   10.152.183.172   <none>        8888/TCP                     126m
+service/lab-core                      ClusterIP   10.152.183.248   <none>        9443/TCP                     126m
+service/lab-nginx                     ClusterIP   10.152.183.155   <none>        443/TCP                      126m
+service/lab-datalake                  ClusterIP   10.152.183.191   <none>        9443/TCP                     126m
+service/lab-dev                       ClusterIP   10.152.183.122   <none>        9443/TCP                     126m
+service/lab-kafka                     ClusterIP   10.152.183.79    <none>        9092/TCP                     126m
+service/lab-odpi-egeria-lab-factory   ClusterIP   10.152.183.158   <none>        9443/TCP                     126m
+service/lab-uistatic                  ClusterIP   10.152.183.156   <none>        80/TCP                       126m
+service/lab-presentation              ClusterIP   10.152.183.61    <none>        8091/TCP                     126m
+service/lab-ui                        ClusterIP   10.152.183.186   <none>        8443/TCP                     126m
+
+NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/lab-odpi-egeria-lab-presentation   1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-nginx          1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-ui             1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-uistatic       1/1     1            1           126m
+deployment.apps/lab-odpi-egeria-lab-jupyter        1/1     1            1           126m
+
+NAME                                                         DESIRED   CURRENT   READY   AGE
+replicaset.apps/lab-odpi-egeria-lab-presentation-bd9789747   1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-nginx-7b96949b4f         1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-ui-74cc464575            1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-uistatic-7b98d4bf9b      1         1         1       126m
+replicaset.apps/lab-odpi-egeria-lab-jupyter-77b6868c4        1         1         1       126m
+
+NAME                                            READY   AGE
+statefulset.apps/lab-odpi-egeria-lab-dev        1/1     126m
+statefulset.apps/lab-zookeeper                  1/1     126m
+statefulset.apps/lab-kafka                      1/1     126m
+statefulset.apps/lab-odpi-egeria-lab-core       1/1     126m
+statefulset.apps/lab-odpi-egeria-lab-datalake   1/1     126m
+statefulset.apps/lab-odpi-egeria-lab-factory    1/1     126m
+````
+
+All of the `pod/...` listed at the top have `Running` as their `STATUS` and `1/1` under `READY`.)
+
+## Accessing the Jupyter notebooks
+
+We now need to get connectivity to the interesting pods, such as that running the Jupyer notebook server, as this is where you'll get to the examples.
+
+Since k8s implementations vary one simple approach for local testing is to use `kubectl port-forward` to connect to the relevant service.
+
+If you look in the list of services above (`kubectl get services`) we have one named 'service/lab-jupyter' so let's try that (with microk8s):
+```shell
+$ kubectl port-forward service/lab-jupyter 8888:8888                                                                  [13:53:52]
+Forwarding from 127.0.0.1:8888 -> 8888
+Forwarding from [::1]:8888 -> 8888
+```
+This command will not return - the port forwarding is active whilst it's running. In this example we're forwarding all requests to local port 8888 to the k8s service for jupyter
+
+At this point you should be able to access your notebooks by going to this forwarded port ie 'http://localhost:8888'
+
+## Accessing the React UI
+
+We repeat the port forwarding above, this time for another service
+```shell
+$ kubectl port-forward service/lab-presentation 8091:8091                                                             [14:15:37]
+Forwarding from 127.0.0.1:8091 -> 8091
+Forwarding from [::1]:8091 -> 8091
+```
+As before, you can define an Ingress, or use nodeports instead if preferred.
+
+Now go to https://localhost:8091/coco to access the React UI. Login as 'garygeeke',password 'admin'.
+
+## Accessing the Egeria UI
+
+The same applies to the service exposing Egeria UI via nginx
+
+```shell
+$ kubectl port-forward service/lab-nginx 8443:443
+Forwarding from 127.0.0.1:8443 -> 443
+Forwarding from [::1]:8443 -> 443
+```
+Now you can go to https://localhost:8443 to access Egeria UI.
+
+## Starting over
+
+Because the environment is entirely self-contained, you can easily start over the labs simply
+by deleting the deployment and running the installation again. This will wipe out all of the
+metadata across the lab Egeria servers, remove all messages from the Kafka bus used in the cohort,
+reset the Jupyter notebooks to their original clean state, etc.
+
+To delete the deployment, simply run this:
+
+```bash
+$ helm delete lab
+```
+
+Where `lab` is the name you used in your original deployment. (You can see what it's called by first running `helm list` and reviewing the output.)
+
+(Then just re-run the last command in the Installation section above to get a fresh environment.)
+
+## Overriding Configuration
+
+The chart is configured to use a default set of parameters.  You can override these by creating a file such as `lab.yaml` with the  contents of any values you wish to modify, for example:
+
+```
+service:
+  type: NodePort
+  nodeport:
+    jupyter: 30888
+    core: 30080
+    datalake: 30081
+    dev: 30082
+    factory: 30083
+    ui: 30443
+```
+
+Refer to the existing values file for additional ports in this section that may reflect new components as added
+
+You can then deploy using
+`helm install lab odpi-egeria-lab -f lab.yaml` which will override standard defaults with your choices
+
+## Enabling persistence
+
+Support has been added to use persistence in these charts. See 'values.yaml' for more information on this option.
+You may also wish to refer to the 'egeria-base' helm chart which is a deployment of a single, persistent, autostart server with UI.
+
+Note however that since this will save the state of your configuration done from
+the tutorial notebooks it may be confusing - as such this is disabled by default. It may be useful if you are modifying the charts for your own use.
+
+You will also need to delete all storage associated with the chart manually if you want to cleanup/reset - for example
+```bash
+kubectl delete pvc --all
+kubectl delete pv --all
+```
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/container-images.md
+++ b/site/docs/guides/operations/kubernetes/container-images.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# Container Images
+
+
+This section will list the current images we produce for Egeria to aid those who wish to setup their own container-based deployment of Egeria.
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/custom_deployment.md
+++ b/site/docs/guides/operations/kubernetes/custom_deployment.md
@@ -1,0 +1,9 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Creating your own Helm chart and deployment
+
+This section will add useful tips on extending the provided charts
+to deploy Egeria in your own environment.
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/helm.md
+++ b/site/docs/guides/operations/kubernetes/helm.md
@@ -1,0 +1,81 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Helm
+
+_Helm is the best way to find, share, and use software built for Kubernetes._ - https://helm.sh
+
+## Deploying apps in Kubernetes
+
+In Kubernetes, resources such as pods (to run code) or services (for network accessibility) are defined in yaml. One or more documents can be submitted at a time.
+
+So we might have one yaml file that defines our pod - with information about which container images to run, and another to setup a network service. finally we may have another that describes our storage requirements (a persistent volume claim
+)
+
+## What does Helm do?
+
+Helm provides a way of bunding yaml files together into an archive, together with a templating mechanism to allow reuse of common patterns & ensure different yamls are consistent and can reference each other.
+
+These archives are known as 'Charts' and can be hosted in a known format as a 'chart repository'. The archives are versioned.
+
+Helm is basically focussed on creating yaml documents that are submitted to Kubernetes - it is not involved in the runtime of a Kubernetes environment. Once a helm app is installed, interaction is just with the regular kubernetes objects.
+
+[Helm Commands](https://helm.sh/docs/helm/helm/) include options to
+* install
+* uninstall
+* list
+* search
+* upgrade
+* rollback
+
+## helm under microk8s
+
+microk8s qualifies the Helm command `helm` in that you need to use `microk8s helm3` so either
+* When docs refer you to type `helm` then just use `microk8s helm3`
+* add a shell alias ie `alias helm='microk8s helm3'` into ~/.zshrc or equivilent shell startup script - if this doesn't clash with your other usage of k8s.
+
+If using this approach you not need to explicitly install Helm.
+
+## Installing Helm
+
+Some Kubernetes environments may install helm as part of their client tooling, refer to the docs to see if this is the case, and run `helm version` to check - expect to use v3 or above. If so, install can be skipped.
+
+### MacOS
+
+If using macOS with HomeBrew installed, helm can be simply installed with
+```shell
+brew install helm
+```
+
+### Other platforms (Linux, Windows)
+
+See the [Installation Guide](https://helm.sh/docs/intro/install/) for more ways to install Helm
+
+## Accessing the egeria charts repository
+
+Our helm charts for Egeria are stored in a repository hosted on GitHub. The source for these is at https://github.com/odpi/egeria-charts , and as charts are updated they are automatically published to a GitHub pages Website (in fact this one!)
+
+Run the following to add this repository
+```shell
+helm repo add egeria https://odpi.github.io/egeria-charts
+```
+
+Before searching or installing, always update your local copy of the repository
+```shell
+helm repo update egeria
+```
+You can now list released charts:
+```shell
+helm search repo egeria
+```
+
+or development charts (being worked on, or using code from master)
+```shell
+helm search repo egeria --devel
+```
+and install a chart that looks interesting - 
+```shell
+helm install egeria/<chart>
+```
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/intro.md
+++ b/site/docs/guides/operations/kubernetes/intro.md
@@ -1,0 +1,23 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# Egeria & Kubernetes
+
+Kubernetes offers one standard way of deploying the Egeria platform into a variety of environments including a developer desktop, or a public cloud environment:
+
+* [Introduction to Kubernetes](k8s.md)
+ 
+* [Introduction to Helm](helm.md)
+ 
+* [Sample chart - the Coco Pharmaceuticals lab](chart_lab.md)
+
+* [Sample chart - base egeria setup](chart_base.md)
+
+* [Container images](container-images.md)
+
+* [Developing a custom deployment](custom_deployment.md)
+
+* [Egeria Operator](operator.md)
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/k8s.md
+++ b/site/docs/guides/operations/kubernetes/k8s.md
@@ -1,0 +1,191 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+# What is Kubernetes?
+
+_Kubernetes, also known as K8s, is an open-source system for automating deployment, scaling, and management of containerized applications._ - https://kubernetes.io
+
+This is how the [official website](https://kubernetes.io/) [describes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) it. It's effectively a standardized way of deploying applications in a very scalable way - from everything such as development prototyping through to massive highly available enterprise solutions.
+
+In this document I'll give a very brief summary that should help those of you new to Kubernetes to make your first steps with Egeria.
+
+# What are the key concepts in Kubernetes?
+
+These are just some of the concepts that can help to understand what's going on. This isn't a complete list.
+
+## Api
+
+Kubernetes using a standard [API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/) which is oriented around manipulating Objects. The commands are therefore very standard, it's all about the objects.
+
+
+
+## Making it so
+The system is always observing the state of the system through these objects, and where there are discrepancies, taking action to 'Make it So' as Captain Picard would say. The approach is imperitive. So we think of these [objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/) as describing the _desired state_ of the system.
+
+## Namespace
+
+A [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) provides a way of seperating out kubernetes resources by users or applications as a convenience. It keeps names more understandable, and avoids global duplicates.
+
+For example a developer working on a k8s cluster may have a namespace of their own to experiment in.
+
+## Container
+
+A [Container](https://kubernetes.io/docs/concepts/containers/) is what runs stuff. It's similar to a Virtual Machine in some ways, but much more lightweight. Containers use code Images which may be custom built, or very standard off-the-shelf reusable items. Containers are typically very focussed on a single need or application. 
+
+## Pod
+
+A [Pod](https://kubernetes.io/docs/concepts/workloads/pods/) is a single group of one or more containers. Typically a single main container runs in a pod, but this may be supported by additional containers for log, audit, security, initialization etc. Think of this as an atomic unit that can run a workload.
+
+Pods are disposeable - they will come and go. Other objects are concerned with providing a reliable service.
+
+## Service
+
+A [service](https://kubernetes.io/docs/concepts/services-networking/service/) provides network accessibility to one or more pods. The service name will be added into local Domain Name Service (DNS) for easy accessibility from other pods. Load can be shared across multiple pods
+
+## Ingres
+
+Think of [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)  as the entry point to Kubernetes services from an external network perspective - so it is these addresses external users would be aware of.
+
+## Deployment 
+
+A [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) keeps a set of pods running - including replica copies, ie restarted if stopped, matching resource requirements, handling node failure .
+
+## Stateful Set
+
+A [stateful set](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) goes further than a deployment in that it keeps a well known identifier for each identical replica. This helps in allocating persistent storage & network resources to a replica
+
+## ConfigMap
+
+A [config map](https://kubernetes.io/docs/concepts/configuration/configmap/) is a way of keeping configuration (exposed as files or environment variables) seperate to an application.
+
+## Secret
+
+A [secret](https://kubernetes.io/docs/concepts/configuration/secret/) is used to keep information secret, as the name might suggest ... This might be a password or an API key & the data is encrypted
+
+## Custom Objects
+
+In addition to this list -- and many more covered in the official documentation -- Kubernetes also supports custom resources. These form a key part of Kubernetes [Operators](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/). 
+
+## Storage
+
+Pods can request storage - which is known as a persistent volume claim (PVC), which are either manually or automatically resolved to a persistent volume.
+
+See the k8s docs [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+
+
+# Why are we using Kubernetes?
+
+ All sizes of systems can run kubernetes applications - from a small raspberry pi through desktops and workstations through to huge cloud deployments. 
+
+Whilst the details around storage, security, networking etc do vary by implementation, the core concepts, and configurations work across all.
+
+Some may be more concerned about an easy way to play with development code, try out new ideas, whilst at the far end of the spectrum enterprises want something super scalable and reliable, and easy to monitor.
+
+For egeria we want to achieve two main things
+* Provide easy to use demos and tutorials that show how Egeria can be used and worked with without requiring too much complex setup. 
+* Provide examples that show how Egeria can be deployed in k8s, and then adapted for the organization's needs.
+
+Other alternatives that might come to mind include
+ * Docker -- whilst simple, this is more geared around running a single container, and building complex environment means a lot of work combining application stacks together, often resulting in something that isn't usable. We do of course still have container images, which are essential to k8s, but these are simple & self contained.
+ * docker-compose -- this builds on docker in allowing multiple containers and servers to be orchestrated, but it's much less flexible & scalable than kubernetes.
+
+# How do I get access to Kubernetes?
+
+[Getting Started](https://kubernetes.io/docs/setup/) provides links to setting up Kubernetes in many environments. Below we'll take a quick look at some of the simpler examples, especially for new users.
+
+## microk8s (Linux, Windows, macOS)
+
+**[Official microk8s site](https://microk8s.io)**
+
+4GB is recommended as a minimum memory requirement.
+
+As with most k8s implementations, when running some ongoing cpu will be used, so if running on your laptop/low power device it's recommended to refer to the relevant docs & stop k8s when not in use.
+
+When running on a separate server or a cloud service this isn't a concern.
+
+When using microk8s, note that the standard k8s commands are renamed to avoid clashes, so use the microk8s ones in the remainder of the Egeria documentation
+
+kubectl -> microk8s kubectl
+helm -> microk8s helm
+
+They can also be aliased on some platforms.
+
+### MacOS
+The [macos install](https://microk8s.io/#tab-three__content) docs cover the steps needed to install microk8s.
+
+Most of the Egeria development team use MacOS, so the instructions are elaborated and qualified here:
+
+* The recommended approach uses [HomeBrew](https://brew.sh). This offers a suite of tools often found on linux which are easy to setup on macOS. See [install docs](https://docs.brew.sh/Installation)
+* IMPORTANT: Before installing, go into System Preferences->Security & Privacy. Click the lock to get into Admin mode. Then ensure Firewall Options->Enable Stealth Mode is NOT enabled (no tick). **If it is, microk8s will not work properly**. [More](https://github.com/ubuntu/microk8s/issues/2509)
+* If you are concerned over the firewall change, or homebrew requirement, refer back to the official k8s documentation & choose another k8s implementation that works for you.
+* Ensure you turn on the following services: storage, dns, helm3 . 
+* dashboard is also useful to understand more about k8s and what is running. However it is currently failing as described in [issue 2507](https://github.com/ubuntu/microk8s/issues/2507)
+
+As an example, the following commands should get you set up, but always check the official docs for current details
+
+```shell
+brew install ubuntu/microk8s/microk8s
+microk8s install
+microk8s status --wait-ready
+microk8s enable dns storage helm3
+microk8s kubectl get all --all-namespaces
+```
+Kubernetes is now running.
+
+### Windows
+
+Follow the [official instructions](https://microk8s.io/#tab-two__content) (untested)
+
+### Linux
+
+Follow the [official instructions](https://microk8s.io/#tab-one__content) (untested)
+
+### kubectl command under microk8s
+
+microk8s qualifies the core k8s command `kubectl` in that you need to use `microk8s kubectl` so either
+* When docs refer you to type `kubectl` then just use `microk8s kubectl`
+* add a shell alias ie `alias kubectl='microk8s kubectl'` into ~/.zshrc or equivilent shell startup script
+
+
+## Docker Desktop (Windows, macOS)
+
+[Docker Desktop](https://www.docker.com/products/docker-desktop) supports Kubernetes
+
+After installing, go into Docker Desktop 'settings and select 'Kubernetes'. Make sure 'Enable Kubernetes' is checked. Also under resources ensure at least 4GB is allocated to Docker
+
+## Cloud
+
+Many cloud providers offer Kubernetes deployments which can be used for experimentation or production. This include
+
+* [Redhat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift/try-it) on multiple cloud providers including on [IBMCloud](https://www.ibm.com/uk-en/cloud/openshift)
+* [Kubernetes on IBMCloud](https://www.ibm.com/cloud/kubernetes-service?p1=Search&p4=43700058232060428&p5=e&gclid=*&gclsrc=aw.ds)
+* [Azure Kubernetes Service](https://azure.microsoft.com/en-us/services/kubernetes-service/)
+* [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) (GKE)
+
+In addition to a cloud install, ensure you have installed the relevant cloud provider's tooling to manage their k8s environment, including having access to the standard kubernetes command `kubectl`.
+
+Note that in the team's testing we mostly are running Redhat OpenShift on IBMCloud as a managed service. We welcome feedback of running our examples on other environments, especially as some of the specifics around ingress rules, storage, security can vary.
+
+## Accessing applications in your cluster
+
+See also [kubernetes docs](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-services/)
+
+### NodePort
+
+In the sample charts provided an option to use a [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport) is usually provided.
+
+This is often easiest when running k8s locally, as any of the ip addressible worker nodes in your cluster can service a request on the port provided. This is why it's named a 'node port' ie a port on your node..
+
+### kubectl port-forward
+
+This can be run at a command line, and directly sets up forwarding from local ports into services running in your cluster. It requires no additional configuration beforehand, and lasts only as long as the port forwarding is running.
+
+See [port forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) for more info
+
+### Ingress
+
+Ingress rules define how traffic directed at your k8s cluster is directed. Their definition tends to vary substantially between different k8s implementations but often is the easiest approach when running with a cloud service.
+
+* [microk8s ingress](https://microk8s.io/docs/addon-ingress) 
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.

--- a/site/docs/guides/operations/kubernetes/operator.md
+++ b/site/docs/guides/operations/kubernetes/operator.md
@@ -1,0 +1,214 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# What is an Operator?
+
+- An operator is a way of extending [Kubernetes](k8s.md) with application specific capababilities. 
+- The notion of 'operator' comes from managing an application through it's lifecycle, just as a human operator would, but here we do it automatically.
+
+Operator functionality could include:
+ - deploying an application
+ - upgrading an applications, perhaps migrating data
+ - taking backups
+ - mapping application specific behaviour into more standard kubernetes commands
+
+A summary of some interesting operators can be found [here](https://github.com/odpi/egeria-k8s-operator/blob/master/doc/research/PopularOperatorCapabilities.md)
+ 
+## Custom Resources
+
+Kubernetes has many standard resource definitions, such as for pods, services, deployments. Instances of each define the intended state of the object it represents.
+
+[Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-resources) Definitions (**CRD**s) extend Kubernetes to allow anything to be represented, such as the intended state of an application stack.  They are defined in yaml. 
+
+Resource definitions include:
+ - apiVersion - consider this the namespace
+ - metadata - useful for searching, selecting
+ - spec - the intended state we are describing
+ - status - used to capture current state
+ 
+An instance of a CRD is known as a Custom Resource (**CR**)
+
+## Controller
+
+There is no intrinsic behaviour associated with a custom resource - it is purely a document with a defined schema. The behaviour is defined by the [Controller](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#custom-controllers), which is code running within the Kubernetes cluster.
+
+The controller's objective is to make reality match the configured Custom Resource. It will watch particular resource types - the primary being the CRD above - and as changes are observed will do whatever is needed to configure application to match the desired intent. It is primarily a reconcilation loop.
+
+The controller will likely use a combination of Kubernetes APIs, perhaps defining and updating other resources, as well as interacting directly with application code within, or external to the cluster.
+
+## Further information
+* [Operator Pattern (Docs, kubernetes.io)](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+* Kubernetes Operator 101 (Blog, Red Hat) - [Part1](https://developers.redhat.com/articles/2021/06/11/kubernetes-operators-101-part-1-overview-and-key-features) | [Part2](https://developers.redhat.com/articles/2021/06/22/kubernetes-operators-101-part-2-how-operators-work#)
+* [Kubernetes Operator (Video, IBM)](https://www.youtube.com/watch?v=i9V4oCa5f9I)
+* [Operators over easy: an introduction to Kubernetes Operators (Video, Red Hat)](https://www.redhat.com/en/blog/operators-over-easy-introduction-kubernetes-operators)
+
+# How does it differ from Helm?
+
+[Helm](helm.md) is a popular way of installing an application stack through charts, and sometimes upgrading. However at it's core, Helm is a templating engine. It takes templates, runs them through a processor to expand variables (across multiple documents). It then submits the documents to the Kubernetes API server just the same as if they'd be created standalone.
+
+Helm charts can be stored in a repository, and make putting together a complex stack relatively easy. (we already use them successfully for Egeria). More complex behaviour can be done by deploying additional containers, jobs etc.
+
+This is **very** different to an operator. Rather than create standard Kubernetes resources, with an operator we are trying to model our application, define it's intended state, and then have active code **always** running to monitor and achieve this. Operators are thus much more sophisticated, but also complex.
+
+Operators and custom resources can themselves be deployed using Helm - so we don't think of the Operators are replacing Helm, rather they are very complementary techniques which can be used together. For example, whist an operator might focus on a single application, a helm chart may deploy a demonstation environment.
+
+# Operator Lifecycle Manager
+
+The [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) (**OLM**) is an optional extension that can be used alongside operators to manage them. OLM allows for operator discovery and manages dependencies between operators.
+
+OLM is [standard in Red Hat OpenShift](https://docs.openshift.com/container-platform/4.8/operators/understanding/olm/olm-understanding-olm.html)
+
+**OLM is not necessary to use operators** - and unlike operators themselves, the framework **is not present in all Kubernetes distibutions**.
+
+# Catalogs
+
+A catalog of operators can be found on [OperatorHub](https://operatorhub.io) and authors can [submit their own operator](https://operatorhub.io/contribute) to help with findability.
+
+# Building an operator
+
+Operators can be built in any language than can support making API calls to Kubernetes. For example it would be possible to write a Java based operator. This is complex, and uses low level APIs, with few examples published. 
+
+The [Operator Framework](https://operatorframework.io) is a toolkit to make it easier to develop an operator by including higher level APIs, and tools for code generation. It supports:
+* [Helm](https://helm.sh) - this wraps up a Helm chart as an operator, but as such it only delivers install/upgrade capability. They can be managed and catalogued as an operator.
+* [Ansible](https://www.ansible.com) - an ansible operator can respond to events & run ansible scripts accordingly. This makes them significantly more flexible
+* [Go](https://www.golangprograms.com) - These are full 'native' operators with full access to the Kubernetes API. Kubernetes itself is written in Go. They are therefore very flexible, though more complex to develop. They do however represent the majority of development in this area, providing also the best scope for help from peers.
+
+A more detailed comparison can be found in this [blog](https://cloud.redhat.com/blog/build-your-kubernetes-operator-with-the-right-tool)
+
+For another project aiming to support java see https://github.com/java-operator-sdk/java-operator-sdk
+
+Egeria is implementing a Go operator, using the Operator Framework. This is the most established & flexible approach.
+
+# Egeria Operator Development
+
+The Egeria operator is being developed at https://github.com/odpi/egeria-k8s-operator - see here for
+* [Issues](https://github.com/odpi/egeria-k8s-operator)
+* prereqs/dependencies
+* feedback, getting involved
+* build, install, and usage instructions
+
+## Design considerations
+
+### Egeria configurations
+
+Custom Resource definitions allow for a very detailed specification of what we want our Egeria deployment to be. However Egeria itself already has a sophisticated approach to configuration - some elements of which are still evolving.
+
+It could be possible to try and fully expose this configuration as a CRD. However due to the complexity, fluidity, and duplication the Operator instead will add k8s deployment specific information around existing Egeria configurations.
+
+It's therefore imperative we keep the **Authoring** of server configuration distinct from **Deployment**. The deployment environment will be different in a Kubernetes environment (hostnames, service names etc)
+
+Initially the egeria config document will be used verbatim, however if processing is needed, a [Admission Webhook](https://sdk.operatorframework.io/docs/building-operators/golang/webhook/) could be used to validate ([validating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook)) & convert ([mutating](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook)) the config before storing in k8s. This approach could also be used for CR validation.
+
+[Example server configuration documents](https://github.com/odpi/egeria-k8s-operator/tree/master/samples/server)
+
+
+### Scaling & failover
+
+Kubernetes is a useful container solution that scales from a raspberry pi to huge cloud deployments. As such it may be used for anything from development to full enterprise production - and this is a strong part of it's appeal. So the operator must support everything from a small development environment, through to a scalable, reliable cloud environment. 
+
+#### Egeria Platform
+
+The [OMAG server platform](https://odpi.github.io/egeria-docs/introduction/overview/#omag-server-platform) (aka 'server chassis') is effectively a java process that is launched and acts as a container for
+running Egeria servers (below). In itself it has relatively little configuration but does include
+- TLS configuration ie passwords, keys, certs
+- Spring configuration (security, plugins)
+
+It offers an admin interface for defining servers (below) and starting/stopping them. It also provides the base URL which is extended for server access.
+
+The platform's connectors are mostly limited to configuration & security.
+
+#### Egeria Servers
+
+The [OMAG Server](https://odpi.github.io/egeria-docs/introduction/overview/#omag-servers) comes in a number of
+different forms including a repository proxy, a metadata repository, a view server etc
+
+A 'server' is a logical concept that actually executes code within an Egeria Platform but is basically what is defined, started, stopped,
+and also hosts the myriad of REST APIs that egeria supports such as for creating the definition of a data asset.
+
+#### So how do we scale?
+
+Three main options are:
+
+ * Model both servers & platforms as different Kubernetes resources. This provides the most accurate mapping, but would require the operator to manage 'scheduling' servers on platforms, and allowing for this to change dynamically as workload & requiremenets change. This would also require having logical URLs unique to each server.
+ * Define servers, and automatically create platforms as needed, resulting in a 1:1 relationship between server and platform. This is simple, though server configuration would need to be overloaded with platform configuration (like ssl keys). This would also lead to creating many more platforms which comes at a resource cost (ram, cpu), as this is a process. Servers however are just logical constructs and have minimal overhead.
+ * Handle replication at the level of platform only. This is close to how Kubernetes works with most apps. 
+
+Whilst initially persuing the first option, due to complexity, the last of these has now been chosen for simplicity.
+
+This has also resulted in the Egeria Platform being the first-class resource we focus on defining for the operator, at least initially. 
+
+### Stateful set vs Deployment 
+
+A Deployment manages scaling of a set of containers (such as egeria platform) across multiple pods. A Statefulset extends this to provide a unique identity which can be used for unique service definitions, or for maintaining an association with dedicated storage.
+
+In the current Egeria helm chart we use a stateful set that that persistent storage can be allocated uniquely to each
+pod & retained across restarts.
+
+However the assumption in the operator environment is that Egeria is stateless (beyond the config & CR), and that any persistent state is managed
+via the connections to metadata storage etc, and that a unique service address is not needed. This latter point may need to be revisited if the Egeria operator needs to actively interact with the individual replicas for control/config, but this is not yet the case, hence the choice of a simpler deployment initially.
+
+### Configuration updates
+
+
+* If a server config document is changed the initially the platform will be restarted. 
+* Later we will try to just restart/stop the modified server and/or perform a rolling change. Care will need to be taken if the config change leads to a conflict.
+
+### Admin requests
+
+* The operator has no knowledge of the state of egeria servers, discovery engines etc.
+* Attempts to perform any admin ops should be blocked (via security plugins to both platform & server)
+* To refine this will require modeling those concepts in the operator
+
+### Metadata repositories
+
+The only metadata repository that offers a suitable HA/remote environment &  supported by the Egeria open source project is [XTDB :material-dock-window:](https://xtdb.com){ target=xtdb }, using the [Egeria XTDB connector](/egeria-docs/connectors/xtdb). 
+
+Note: At this point, the deployment of XTDB itself is outside the scope of the operator.
+
+### Connectors
+
+Much of the capability in Egeria is pluggable. For example we have a connector to the message bus, which could be kafka, but equally
+may be RabbitMQ (if a connector were written). We have connectors that understand data sources such as for Postgres. These are
+implemented as java jars, and are added into the classpath of the egeria platform. Thus the platform can provide a certain capability
+with these additional connectors, but it is the server which defines which ones to use (and refers to the class name to locate)
+
+An Egeria server configuration document therefore contains many references to connectors. The references libraries must be available in the runtime environment ie platform. This is done by ensuring they are pointed to within the spring loader's 'LOADER_PATH' environment variable.
+
+Several approaches are possible:
+* Build a custom container image based on the [Egeria docker image](https://github.com/odpi/egeria/tree/master/open-metadata-resources/open-metadata-deployment/docker/egeria) including the desired connectors, and either placing the required additional files into /deployments/server/lib, or placing them elsewhere in the image and ensuring LOADER_PATH is set
+* Dynamically download or mount the required libraries - and dependencies - when the server platform is set up by the operator, for example through an init job.
+
+Currently the operator takes the former, simpler approach. Therefore specifying a custom container image as part of the platform configuration will often be required.
+
+Connectors also often tend to refer to endpoints - for example the location of a Kafka message bus, a server's own address. Currently the server configuration document
+passed to the operator must have correct addresses. As yet there is no manipulation or templating of these addresses, though this may change in future.
+
+## Operator Development
+
+### Prerelease 
+ - deploy Egeria platforms with a list of servers
+ - uses Kubernetes [ConfigMap](https://kubernetes.io/docs/concepts/configuration/configmap/) to store individual server configuration
+ - requires the user to use repositories capable of supporting replication (like XTDB)
+
+### Still to do for an initial release
+ - Helm chart to deploy a complete demo environment (coco pharma) with Egeria operator & XTDB backend.
+ - working through the full server authoring lifecycle (alongside Server Author UI & View Services) - including templating of connections which contain host:ip from the authoring environment
+ - Evaluating alternative stores of server configuration (at a minimum may need to be a [secret](https://kubernetes.io/docs/concepts/configuration/secret/) as we include auth info - but decided to use ConfigMaps initially for clarity during initial design)
+ - Automated testing & packaging (to both a full k8s cluster & using a test framework)
+ - Further end-user docs on using the operator
+ - publish on [Operator Hub](https://operatorhub.io)
+
+
+### Future enhancements
+ - [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) integration
+ - publish on [Operator Hub](https://operatorhub.io)
+ - refinement of configurations (consolidation, admission webhooks)
+ - consideration of more detailed mapping between Egeria Concepts and operator
+ - rolling platform restart (config update, upgrade etc)
+ - Handling upgrades/migration between egeria versions
+ - Integration with [Prometheus](https://prometheus.io)
+
+
+----
+License: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/),
+Copyright Contributors to the ODPi Egeria project.


### PR DESCRIPTION
This reverts commit a539f169706bcf7c0d90074b1d9446768d97f941.

Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Correct fix to k8s docs originally done in a539f169706bcf7c0d90074b1d9446768d97f941
* Docs were accidentally removed due to a change to exclude 'site' in git exclude in the original PR (but tested ok locally..). The intent was to exclude site/site which has now been fixed in 4c02c9f6fdb4784d1b2b4c512151f7127654c9b9