### PR TITLE
Updated Area Type 7 Docs

### DIFF
--- a/site/docs/types/7/0750-Data-Passing.md
+++ b/site/docs/types/7/0750-Data-Passing.md
@@ -8,7 +8,7 @@ hide:
 
 # 0750 Data Passing
 
-Describes relationships that show where data and control is passed between components.  These relationships show the structure of the data processing.  They can link [Assets](/egeria-docs/types/0/0010-Base-Model), or [Ports](/egeria-docs/types/2/0217-Ports) or [SchemaAttributes](/egeria-docs/types/5/0505-Schema-Attributes) depending on the level of detail that is known.
+Describes relationships that show where data and control is passed between components. These relationships show the structure of the data processing. They can link [Assets](/egeria-docs/types/0/0010-Base-Model/#asset), or [Ports](/egeria-docs/types/2/0217-Ports) or [SchemaAttributes](/egeria-docs/types/5/0505-Schema-Attributes) depending on the level of detail that is known.
 
 ![UML](0750-Data-Passing.svg)
 

--- a/site/docs/types/7/0760-Business-Lineage.md
+++ b/site/docs/types/7/0760-Business-Lineage.md
@@ -9,9 +9,7 @@ hide:
 
 # 0760 Business Lineage
 
-Business lineage is a type of lineage where only elements that have been tagged
-as business significant are shown.  This allows
-some of the technical detail to be eliminated from the display.
+Business lineage is a type of lineage where only elements that have been tagged as business significant are shown. This allows some of the technical detail to be eliminated from the display.
 
 ![UML](0760-Business-Lineage.svg)
 

--- a/site/docs/types/7/0770-Lineage-Mapping.md
+++ b/site/docs/types/7/0770-Lineage-Mapping.md
@@ -9,9 +9,9 @@ hide:
 
 # 0770 - Lineage Mapping
 
-Lineage Mapping identifies elements that are [equivalent to each other in the lineage graph](/egeria-docs/features/lineage-mangement/#lineage-mapping).  It is used to stitch the lineage graph together.
+Lineage Mapping identifies elements that are [equivalent to each other in the lineage graph](/egeria-docs/features/lineage-management/overview/#stitching). It is used to stitch the lineage graph together.
 
-This is contrast with the [Data Passing](0750-Data-Passing.md) relationships that represent implementation relationships between components.
+This is contrast with the [Data Passing](/egeria-docs/types/7/0750-Data-Passing) relationships that represent implementation relationships between components.
 
 ![UML](0770-Lineage-Mapping.svg)
 

--- a/site/docs/types/7/index.md
+++ b/site/docs/types/7/index.md
@@ -8,27 +8,23 @@ hide:
 
 # Area 7 Models - Lineage
 
-Lineage basically describes the origin of something such as an asset,
-component or data values.
+Lineage basically describes the origin of something such as an asset, component or data values.
 
-Area 7 provides the structures for adding context to asset definitions to
-help explain their origin.  The aim is to provide information that allows a consumer of data
-to be sure they are looking at the right data from an authoritative source and the intermediate
-processing is correct.
+Area 7 provides the structures for adding context to asset definitions to help explain their origin.  The aim is to provide information that allows a consumer of data to be sure they are looking at the right data from an authoritative source and the intermediate processing is correct.
 
+- [0710 Digital Service](/egeria-docs/types/7/0710-Digital-Service)
+- [0715 Digital Service Ownership](/egeria-docs/types/7/0715-Digital-Service-Ownership)
+- [0717 Digital Service Implementation](/egeria-docs/types/7/0717-Digital-Service-Implementation)
+- [0720 Information Supply Chains](/egeria-docs/types/7/0720-Information-Supply-Chains)
+- [0730 Solution Components](/egeria-docs/types/7/0730-Solution-Components)
+- [0735 Solution Ports and Wires](/egeria-docs/types/7/0735-Solution-Ports-and-Wires)
+- [0740 Solution Blueprints](/egeria-docs/types/7/0740-Solution-Blueprints)
+- [0750 Data Passing](/egeria-docs/types/7/0750-Data-Passing)
+- [0760 Business Lineage](/egeria-docs/types/7/0760-Business-Lineage)
+- [0770 Lineage Mapping](/egeria-docs/types/7/0770-Lineage-Mapping)
+- [0780 Code Analysis](/egeria-docs/types/7/0780-Code-Analysis)
+- [0790 Incomplete](/egeria-docs/types/7/0790-Incomplete)
 
-* **[0710 Digital Service](0710-Digital-Service.md)**
-* **[0715 Digital Service Ownership](0715-Digital-Service-Ownership.md)**
-* **[0717 Digital Service Implementation](0717-Digital-Service-Implementation.md)**
-* **[0720 Information Supply Chains](0720-Information-Supply-Chains.md)**
-* **[0730 Solution Components](0730-Solution-Components.md)**
-* **[0735 Solution Ports and Wires](0735-Solution-Ports-and-Wires.md)**
-* **[0740 Solution Blueprints](0740-Solution-Blueprints.md)**
-* **[0750 Data Passing](0750-Data-Passing.md)**
-* **[0760 Business Lineage](0760-Business-Lineage.md)**
-* **[0770 Lineage Mapping](0770-Lineage-Mapping.md)**
-* **[0780 Code Analysis](0780-Code-Analysis.md)**
-* **[0790 Incomplete](0790-Incomplete.md)**
 
 ![UML Packages](area-7-lineage-overview.svg)
 


### PR DESCRIPTION
Broken link update and changes to below files.

0770-Lineage-Mapping.md
from /egeria-docs/features/lineage-mangement/#lineage-mapping to /egeria-docs/features/lineage-management/overview/#the-lineage-graph
from 0750-Data-Passing.md file name to /egeria-docs/types/7/0750-Data-Passing

0750-Data-Passing.md
Added Asset reference directly to the Assets hyperlink /egeria-docs/types/0/0010-Base-Model/#asset

0760-Business-Lineage.md
Fixed line breaks

4 index.md
Added /egeria-docs/types/7/ to all the .md files and removed *'s and replaced with - as part of formatting guidelines done for Area type 0,1.