### PR TITLE
Issue5929

### DIFF
--- a/site/docs/release-notes/3-4.md
+++ b/site/docs/release-notes/3-4.md
@@ -15,18 +15,131 @@
     
     If deploying helm charts to OpenShift, a security policy change is needed. See [odpi/egeria-charts#18 :material-dock-window:](https://github.com/odpi/egeria-charts/issues/18){ target=gh }.
 
+??? info "Known issue: Helm chart deployments fail on arm64 (Apple M1, Raspberry pi 64 bit)"
+
+    The docker images built by the Egeria team are now provided as multi-architecture images for both amd64 (Intel) and arm64 (Raspberry pi 64 bit & Apple m1).
+    However at the time of release our 3.4.0 Helm Charts will not function successfully on arm64 since we do not yet
+    have a Kafka implementation for arm64. This will be updated through our Helm charts outside the release cycle. Watch slack's #egeria-announce channel for further information.
 
 ???+ functional "Functional changes"
 
     ??? update "OMAG Server Platform Chassis & Connector Configuration Factory"
 
     [Graph repository connector](https://github.com/odpi/egeria/open-metadata-implementation/adapters/open-connectors/repository-services-connectors/open-metadata-collection-store-connectors/graph-repository-connector/README.md)
-    it is not dependency of [Connector configuration factory](https://github.com/odpi/egeria/open-metadata-implementation/adapters/open-connectors/connector-configuration-factory/README.md) 
-    anymore therefore will not be included by the build into [ OMAG Server Platform Chassis ](ohttps://github.com/odpi/egeria/open-metadata-implementation/server-chassis/server-chassis-spring/README.md).
-    Jar with dependencies of [Graph repository connector](https://github.com/odpi/egeria/open-metadata-implementation/adapters/open-connectors/repository-services-connectors/open-metadata-collection-store-connectors/graph-repository-connector/README.md) 
-    it is now part of the build (maven and gradle) and to run a platform that have server(s) with Egeria graph repository,
-    the connector jar have to be placed into classpath. Easy way is to use Spring boot loader.path functionality. Place the 
-    jar in the 'lib' folder next to server-chassis-spring jar and run it with -Dloader.path=lib
+    is not a dependency of [Connector configuration factory](https://github.com/odpi/egeria/open-metadata-implementation/adapters/open-connectors/connector-configuration-factory/README.md) 
+    anymore, therefore will not be included by the build into [ OMAG Server Platform Chassis ](https://github.com/odpi/egeria/open-metadata-implementation/server-chassis/server-chassis-spring/README.md).jar with dependencies of [Graph repository connector](https://github.com/odpi/egeria/open-metadata-implementation/adapters/open-connectors/repository-services-connectors/open-metadata-collection-store-connectors/graph-repository-connector/README.md) .
+    It is now part of the build (maven and gradle), and to run a platform that have server(s) with Egeria graph repository,
+    the connector jar has to be placed into the classpath. The easiest way is to use Spring boot's loader.path property. Place the 
+    jar in the 'lib' folder next to server-chassis-spring jar and run it with -Dloader.path=lib .
+
+    ??? added "New function to return more detailed server status"
+
+    A new REST API 'GET {{baseURL}}/open-metadata/admin-services/users/{{adminUserId}}/servers/cocoMDS6/instance/status' has been added to returned more detailed status for a server.
+
+    For example a running server will return 
+
+    ```
+    {
+    "class": "OMAGServerStatusResponse",
+    "relatedHTTPCode": 200,
+    "serverStatus": {
+        "serverName": "cocoMDS6",
+        "serverType": "Metadata Server",
+        "serverActiveStatus": "RUNNING",
+        "services": [
+            {
+                "serviceName": "Subject Area OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Open Metadata Repository Services (OMRS)",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Community Profile OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Asset Consumer OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Discovery Engine OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Data Science OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Asset Catalog OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "IT Infrastructure OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Asset Owner OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Asset Manager OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Connected Asset Services",
+                "serviceStatus": "STARTING"
+            },
+            {
+                "serviceName": "Data Manager OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Glossary View OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Data Engine OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Project Management OMAS",
+                "serviceStatus": "RUNNING"
+            },
+            {
+                "serviceName": "Governance Engine OMAS",
+                "serviceStatus": "RUNNING"
+            }
+        ]
+    }
+    ```
+
+    whilst a server still starting could return:
+    ```
+    {
+    "class": "OMAGServerStatusResponse",
+    "relatedHTTPCode": 200,
+    "serverStatus": {
+        "serverName": "cocoMDS2",
+        "serverType": "Metadata Server",
+        "serverActiveStatus": "STARTING",
+        "services": [
+            {
+                "serviceName": "Open Metadata Repository Services (OMRS)",
+                "serviceStatus": "STARTING"
+            }
+        ]
+    }
+    ```
+    Specifically, the serverActiveStatus is defined as
+    ```
+    UNKNOWN    The state of the server is unknown. 
+    STARTING   The server is starting.
+    RUNNING    The server has completed start up and is running.
+    STOPPING   The server has received a request to shutdown.
+    INACTIVE   The server is not running.
+    ```
 
 ???+ types "Type changes: :material-plus-circle: added, :material-adjust: modified, :material-alert-circle: deprecated"
 

--- a/site/docs/release-notes/3-4.md
+++ b/site/docs/release-notes/3-4.md
@@ -15,10 +15,6 @@
     
     If deploying helm charts to OpenShift, a security policy change is needed. See [odpi/egeria-charts#18 :material-dock-window:](https://github.com/odpi/egeria-charts/issues/18){ target=gh }.
 
-??? info "Known issue: Hands-on labs notebook"
-
-    When using the 'understanding platform services' lab notebook, the query for active servers will fail. See [odpi/egeria#5023:material-dock-window:](https://github.com/odpi/egeria/issues/5023){ target=gh }.
-
 
 ???+ functional "Functional changes"
 


### PR DESCRIPTION
Updates release notes for 3.4
 - Removes 'known issue' in notebooks - server status is now fixed
 - adds note on arm64 container images including a note that helm charts won't work due to missing kafka
 - add information on new server status API