### PR TITLE
#116 remove use of --devel for dojo

### DIFF
--- a/site/docs/education/egeria-dojo/running-egeria/coco-labs-environment.md
+++ b/site/docs/education/egeria-dojo/running-egeria/coco-labs-environment.md
@@ -21,7 +21,7 @@ $ helm delete base
 
 Now, install the Coco Pharma environment
 ```console
-$ helm install lab egeria/odpi-egeria-lab --devel                               [15:16:18]
+$ helm install lab egeria/odpi-egeria-lab                                [15:16:18]
 NAME: lab
 LAST DEPLOYED: Fri Jan 14 15:16:33 2022
 NAMESPACE: base

--- a/site/docs/education/egeria-dojo/running-egeria/configuring-and-operating-a-server.md
+++ b/site/docs/education/egeria-dojo/running-egeria/configuring-and-operating-a-server.md
@@ -29,7 +29,7 @@ Now we'll install the same demo again, but this time we are going to set a param
 which prevents the servers being automatically configured, so that we can walk through
 this in the tutorial:
 ```console
-$ helm install base egeria/egeria-base --devel --set egeria.config=false
+$ helm install base egeria/egeria-base  --set egeria.config=false
 LAST DEPLOYED: Fri Jan  7 16:36:20 2022
 NAMESPACE: default
 STATUS: deployed

--- a/site/docs/education/egeria-dojo/running-egeria/simple-install.md
+++ b/site/docs/education/egeria-dojo/running-egeria/simple-install.md
@@ -62,16 +62,15 @@ Update Complete. ⎈Happy Helming!⎈
 First we'll look at what charts are available:
 
 !!! Info
-    You'll see we use `--devel` on these commands. This retrieves the very latest, unreleased, versions of our charts.
-    We're using this as they are still being written and updated. Very soon the charts will be published
-    as new versions, and this parameter will be removed from the documentation.
+    If you need to check out the very latest charts we are developing, you can add `--devel` on these commands. This retrieves the very latest, unreleased, versions of our charts.
+
 ```console
-$ helm search repo egeria --devel
+$ helm search repo egeria 
 NAME                  	CHART VERSION     	APP VERSION	DESCRIPTION
-egeria/egeria-base    	3.4.1-prelease.3  	3.4        	Egeria simple deployment (platform, react UI)
+egeria/egeria-base    	3.4.1           	3.4        	Egeria simple deployment (platform, react UI)
 egeria/egeria-cts     	3.4.0             	3.4        	Egeria Conformance Test Suite deployment to Kub...
 egeria/egeria-pts     	3.4.0             	3.4        	Egeria Performance Test Suite deployment to Kub...
-egeria/odpi-egeria-lab	3.4.1-prerelease.6	3.4        	Egeria lab environment
+egeria/odpi-egeria-lab	3.4.1           	3.4        	Egeria lab environment
 $
 ```
 
@@ -82,7 +81,7 @@ This list will change as the Egeria team continue to develop these charts
 We'll now install a simple Egeria configuration:
 
 ```console
-$ helm install base egeria/egeria-base --devel
+$ helm install base egeria/egeria-base 
 NAME: base
 LAST DEPLOYED: Tue Jan 11 18:44:18 2022
 NAMESPACE: default


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

The new helm charts are now 'released'

We therefore need to remove the use of '--devel' from the helm invocations used in the tutorial
(Though this option has been added as a note)

This simplifies the instructions, and insulated the dojo user from ongoing experimental chart changes