### PR TITLE
Update instructions for installing charts

### DIFF
--- a/site/docs/guides/operations/kubernetes/charts/base.md
+++ b/site/docs/guides/operations/kubernetes/charts/base.md
@@ -27,11 +27,14 @@ No configuration of the chart is required to use defaults, but information is pr
 
 ## Installation
 
-```console
-helm install base egeria/egeria-base
+```shell
+helm repo add egeria https://odpi.github.io/egeria-charts
+helm repo update
+helm install [-f overrides.yaml] <name> egeria/egeria-base
 ```
+where <name> is whatever you want to call your installed chart, and the -f is optional, if you have overriding values to supply.
 
-**THE INSTALL WILL TAKE SEVERAL MINUTES** to complete
+**THE INSTALL WILL TAKE SEVERAL MINUTES** to complete in the background, after the chart has deployed.
 
 This is because it is not only creating the required
 objects in Kubernetes to run the platforms, but also is configuring egeria itself - which involves waiting

--- a/site/docs/guides/operations/kubernetes/charts/cts.md
+++ b/site/docs/guides/operations/kubernetes/charts/cts.md
@@ -18,8 +18,9 @@ No configuration of the chart is required to use defaults, but information is pr
 
 !!! cli "Install (deploy) the CTS chart"
     ```shell
-    helm dep update egeria-cts
-    helm install [-f overrides.yaml] <name> egeria-cts
+    helm repo add egeria https://odpi.github.io/egeria-charts
+    helm repo update
+    helm install [-f overrides.yaml] <name> egeria/egeria-cts
     ```
 
     The `-f overrides.yaml` is optional, and only necessary if you are overriding any of the configuration (see options below), while the `<name>` is the name you want to give your deployment.

--- a/site/docs/guides/operations/kubernetes/charts/lab.md
+++ b/site/docs/guides/operations/kubernetes/charts/lab.md
@@ -29,10 +29,14 @@ You no longer need a git clone of this repository to install the chart.
 
 ## Installation
 
-```console
-helm install lab egeria/odpi-egeria-lab
+```shell
+helm repo add egeria https://odpi.github.io/egeria-charts
+helm repo update
+helm install [-f overrides.yaml] <name> egeria/odpi-egeria-lab
 ```
+where <name> is whatever you want to call your installed chart, and the -f is optional, if you have overriding values to supply.
 
+Example output: 
 ```console
 $ helm install lab egeria/odpi-egeria-lab
 NAME: lab

--- a/site/docs/guides/operations/kubernetes/charts/pts.md
+++ b/site/docs/guides/operations/kubernetes/charts/pts.md
@@ -18,8 +18,9 @@ This is a deployment of Egeria that will automatically run the [Performance Test
 
 !!! cli "Install (deploy) the PTS chart"
     ```shell
-    helm dep update egeria-pts
-    helm install [-f overrides.yaml] <name> egeria-pts
+    helm repo add egeria https://odpi.github.io/egeria-charts
+    helm repo update
+    helm install [-f overrides.yaml] <name> egeria/egeria-pts
     ```
 
     The `-f overrides.yaml` is optional, and only necessary if you are overriding any of the configuration (see options below), while the `<name>` is the name you want to give your deployment.


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Updates instructions for installing helm charts
 * includes command to add egeria repository (easier than back-linking)
 * installs from repository, rather than local file - the latter only likely being done by developers editing the charts, and these are in our user docs.