### PR TITLE
Fix  content images in dark-mode

### DIFF
--- a/site/docs/assets/stylesheets/egeria.css
+++ b/site/docs/assets/stylesheets/egeria.css
@@ -501,3 +501,10 @@
   height: 100%;
   border: 0;
 }
+
+/*Making SVG images from content when dark mode white background and 10px padding*/
+body[data-md-color-scheme="slate"] .md-content img[src $= "svg"],
+body[data-md-color-scheme="slate"] .md-content img[src $= "png"]{
+    background-color: white;
+    padding: 10px;
+}


### PR DESCRIPTION
The images in the content are mostly .svg or .png with transparent background.
Added CSS selector for dark theme and place a white background and 10px padding.