### PR TITLE
Kafka topic connector update & release notes

### DIFF
--- a/site/docs/guides/diagnostic/examples-of-server-start-up-errors.md
+++ b/site/docs/guides/diagnostic/examples-of-server-start-up-errors.md
@@ -162,11 +162,8 @@ Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.erro
 	... 61 more
 Caused by: org.apache.kafka.common.errors.TimeoutException: Call(callName=listNodes, deadlineMs=1620829049902, tries=1, nextAllowedTryMs=1620829050010) timed out at 1620829049910 after 1 attempt(s)
 Caused by: org.apache.kafka.common.errors.TimeoutException: Timed out waiting for a node assignment. Call: listNodes
-
-
 ```
-
-
+Refer to [kafka topic connector](/connectors/resource/kafka-open-metadata-topic-connector) for more information on the connector behaviour and configuration options including startup behaviour.
 
 
 ## Further information

--- a/site/docs/release-notes/3-10.md
+++ b/site/docs/release-notes/3-10.md
@@ -1,0 +1,116 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+# Release 3.10 (Planned for July 2022)
+
+??? warning "Known Issues"
+
+    This section highlights any significant issues to be aware of. Refer to our [GitHub Issues](https://github.com/odpi/egeria/issues) for a full list of open issues or to open a new one.
+
+    ??? info "Use chromium-based or Safari browser for UIs"
+         It is recommended to use a chromium-based browser such as Google Chrome, Microsoft Edge or Apple Safari for the Egeria Ecosystem UI. Some parts of the UI experience such as Dino currently experience problems with Firefox. See [odpi/egeria-react-ui#96 :material-dock-window:](https://github.com/odpi/egeria-react-ui/issues/96){ target=gh }.
+
+    ??? info "inmemory repository intermittent/timing issue"
+
+        We have noticed a few issues with the in-memory repository during testing which are still being investigated:
+
+        * [odpi/egeria#6549](https://github.com/odpi/egeria/issues/6549){ target=gh }
+        * [odpi/egeria/#6552](https://github.com/odpi/egeria/issues/6552){ target=gh }
+
+        Both have only been in specific testcases and are intermittent, most likely timing related.
+
+        These issues have not been seen with the local graph repository.
+
+        If you do see any problems in this area, please comment on the issue or get in touch via our usual channels.
+
+
+    ??? info "cohort initialization timing"
+
+        [odpi/egeria#6549](https://github.com/odpi/egeria/issues/6549){ target=gh } records a very specific issue seen in automated
+        testing where multiple servers did not fully register in a cohort. A short delay addressed the immediate
+        issue, but we are still investigating the root cause. This issue has not been noticed in more usual usage.
+
+        If you do see any problems in this area, please comment on the issue or get in touch via our usual channels.
+
+    ??? info "Ecosystem UI minor issues"
+
+        We are continuing to develop the Ecosystem UI & improve it's capability and usability. These are not regressions in this release. Known issues include:
+
+        * [odpi/egeria-react-ui#461](https://github.com/odpi/egeria-react-ui/issues/463){ target=gh } - Dino: cannot retrieve server audit log twice.
+        * [odpi/egeria-react-ui#465](https://github.com/odpi/egeria-react-ui/issues/463){ target=gh } - Dino: Error retrieving cohort information in Dino.
+        * [odpi/egeria-react-ui#464](https://github.com/odpi/egeria-react-ui/issues/464){ target=gh } - Buttons can appear off screen. Workaround is to enlarge window.
+        * [odpi/egeria-react-ui#465](https://github.com/odpi/egeria-react-ui/issues/465){ target=gh } - Search dialog still appears if no server selected.
+
+        See [odpi/egeria-react-ui](https://github.com/odpi/egeria-react-ui/issues){ target=gh } for all issues or to open a new one on this UI.
+
+    ??? info "Business UI lab - asset not found"
+
+        The 'Egeria UI' lab notebook (ui-labs/ui-asset-search.ipynb) explains how to search for an asset in the UI. This does not work for the asset listed.
+        See [odpi/egeria#6547](https://github.com/odpi/egeria/issues/6547){ target=gh } for more information.
+
+    ??? info "Documentation Link errors"
+
+        We are aware of broken links in the documentation here, as well as broken links to the documentation contained within the egeria code -
+        for example links to component information.
+
+        We are trying to fix these as we update the docs, but please raise any additional problems found in [egeria-docs](https://github.com/odpi/egeria-docs/issues){ target=gh }.
+        We would also be very grateful for any PRs that fix issues.
+    
+
+??? functional "Functional changes"
+
+
+    ??? info "Server startup behaviour when kafka unavailable"
+
+         Server start will now fail if the server is configured in a way that requires Kafka, but it is not available. Audit log messages and client API calls return specific information. Previously the server would start, but would not be connected to any configured cohorts, resulting in incorrect behaviour. See [kafka topic connector](/connectors/resource/kafka-topic-connector) for more information.
+
+          Ref: [odpi/egeria#6530](https://github.com/odpi/egeria/issues/6530)
+
+    ??? info "Server startup behaviour with invalid metadata collection"
+
+         Server start will now fail if the metadata collection identifier of the server has been changed. Previously the server would start, but with an invalid metadata collection id resulting in incorrect behaviour & potential data corruption in the cohort. See [kafka topic connector](/connectors/resource/kafka-topic-connector) for more information. 
+
+          Ref: [odpi/egeria#6612](https://github.com/odpi/egeria/issues/6612)
+
+    See full changelog for details (below)
+
+
+??? functional "Helm Charts"
+
+    ... to be updated prior to release ...
+
+    These charts may get updated more frequently than Egeria code releases, as we integrate other components and fix bugs. You can always check the latest with `helm repo update && helm search repo egeria `
+
+    Note that the Business UI remains at an older version, as the code is currently undergoing some refactoring.
+
+    To see known issues/upcoming work or to report issues see [egeria-charts](https://github.com/odpi/egeria-charts/issues){ target=gh }
+
+    ??? info "Lab Chart for 3.9"
+
+         The Egeria lab chart 3.9.0 has been updated to include:
+
+         * Egeria 3.9
+         * Egeria Ecosystem UI 3.8.0
+         * Egeria Business UI 3.2.0
+         * Strimzi 0.29
+
+    ??? info "Base Chart for 3.9"
+
+         The Egeria base chart 3.9.0 has been updated to include:
+
+         * Egeria 3.9
+         * Egeria Ecosystem UI 3.8.0
+         * Strimzi 0.29
+
+
+    ??? info "CTS & PTS Charts for 3.9"
+
+         * Egeria 3.9
+         * Strimzi 0.29
+
+??? bugs "Bug fixes and other updates"
+
+    For details on core egeria changes, see the [Github release note for 3.9](https://github.com/odpi/egeria/releases/tag/V3.9){ target=gh } and the full [commit history in GitHub :material-dock-window:](https://github.com/odpi/egeria/commits){ target=gh }.
+
+
+--8<-- "snippets/abbr.md"


### PR DESCRIPTION
* Updated kafka connector doc
 - Min pause time vs kafka api times
 - recommend kafka started beforehand with K8s reference
 - noted that server startup fails if kafka cannot be connected to 

* Updated diagnostics guide
 - reference to kafka connector doc added to sample kafka error
 
 * Updates release notes
  - reference to this change in behaviour for kafka
  - also documented change in behaviour where server startup will be abandoned if an invalid metadata collection id is found