### PR TITLE
odpi/egeria-charts#117 coexistance of multiple helm charts

### DIFF
--- a/site/docs/guides/operations/kubernetes/charts/overview.md
+++ b/site/docs/guides/operations/kubernetes/charts/overview.md
@@ -5,14 +5,14 @@
 
 This set of charts has been built to assist in learning & demonstration activities, testing, and may also form a basis for production deployments.
 
-See [../helm](Helm) for information on configuring Helm to be able to access these charts via a repository.
+See [Helm](../helm.md) for information on configuring Helm to be able to access these charts via a repository.
 
 # Available Charts
 
-* [base](base) - creates a simple Egeria environment with a single metadata server. Includes the Ecosystem UI so that metadata can be searched, browsed.
-* [odpi-egeria-lab](lab) - Demo scenario for 'Coco Pharmaceuticals'. Multiple platorms, metadata repositories, cohorts. Demonstration script via Juypter notebooks. Includes both the Ecosystem UI & business UI 
-* [cts](cts) - Supports testing repository connectors using our Conformance Test Suite. Can be configured to support other repositories via simple values.
-* [pts](pts) - Performance test suite to aid in measuring the performance of repository connectors.
+* [base](base.md) - creates a simple Egeria environment with a single metadata server. Includes the Ecosystem UI so that metadata can be searched, browsed.
+* [odpi-egeria-lab](lab.md) - Demo scenario for 'Coco Pharmaceuticals'. Multiple platorms, metadata repositories, cohorts. Demonstration script via Juypter notebooks. Includes both the Ecosystem UI & business UI 
+* [cts](cts.md) - Supports testing repository connectors using our Conformance Test Suite. Can be configured to support other repositories via simple values.
+* [pts](pts.md) - Performance test suite to aid in measuring the performance of repository connectors.
 
 # Caveat: Strimzi: permissions and co-existance
 

--- a/site/docs/guides/operations/kubernetes/charts/overview.md
+++ b/site/docs/guides/operations/kubernetes/charts/overview.md
@@ -1,0 +1,37 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the ODPi Egeria project. -->
+
+# Introduction to the Egeria Helm Charts
+
+This set of charts has been built to assist in learning & demonstration activities, testing, and may also form a basis for production deployments.
+
+See [../helm](Helm) for information on configuring Helm to be able to access these charts via a repository.
+
+# Available Charts
+
+* [base](base) - creates a simple Egeria environment with a single metadata server. Includes the Ecosystem UI so that metadata can be searched, browsed.
+* [odpi-egeria-lab](lab) - Demo scenario for 'Coco Pharmaceuticals'. Multiple platorms, metadata repositories, cohorts. Demonstration script via Juypter notebooks. Includes both the Ecosystem UI & business UI 
+* [cts](cts) - Supports testing repository connectors using our Conformance Test Suite. Can be configured to support other repositories via simple values.
+* [pts](pts) - Performance test suite to aid in measuring the performance of repository connectors.
+
+# Caveat: Strimzi: permissions and co-existance
+
+When any of the above charts are deployed, they include the install of the Strimzi operator (for kafka). However Strimzi deploys some cluster-scoped resources which has two implications:
+
+* Admin level to the cluster permissions are needed - since cluster resources need to be deployed. Without these permissions the Charts will not work
+* As the resources are cluster-level you cannot install a second chart - or additional install of the same chart as clashes will be seen on these resources. So no testing, debug in parallel or shared k8s clusters for multiple develoeprs
+
+To address this, the charts all have the option to NOT install Strimzi. If this is done
+* You can install multiple charts (recommended 1 per namespace) for the same, or different, user.
+* You do not need such high permissions to install the Egeria chart
+
+To skip the install add the following to the install: `--set strimzi.enabled=false` ie:
+```
+helm install base egeria-base --set strimzi.enabled=false
+```
+
+You DO need Strimzi already installed by an admin
+* See Strimzi docs for information for [installing Strimzi via Helm](https://strimzi.io/blog/2018/11/01/using-helm/) or alternatively install another way, such as via the operator catalog.
+* Ensure the strimzi operator is configured to [watch all namespaces](https://strimzi.io/docs/operators/latest/full/configuring.html#deploying-cluster-operator-to-watch-whole-cluster-str) (or at least includes the ones you want to use)
+
+---8<-- "snippets/abbr.md"

--- a/site/docs/guides/operations/kubernetes/charts/overview.md
+++ b/site/docs/guides/operations/kubernetes/charts/overview.md
@@ -7,31 +7,32 @@ This set of charts has been built to assist in learning & demonstration activiti
 
 See [Helm](../helm.md) for information on configuring Helm to be able to access these charts via a repository.
 
-# Available Charts
+## Available Charts
 
 * [base](base.md) - creates a simple Egeria environment with a single metadata server. Includes the Ecosystem UI so that metadata can be searched, browsed.
-* [odpi-egeria-lab](lab.md) - Demo scenario for 'Coco Pharmaceuticals'. Multiple platorms, metadata repositories, cohorts. Demonstration script via Juypter notebooks. Includes both the Ecosystem UI & business UI 
+* [odpi-egeria-lab](lab.md) - Demo scenario for 'Coco Pharmaceuticals'. Multiple platorms, metadata repositories, cohorts. Demonstration script via Juypter notebooks. Includes both the Ecosystem UI & business UI .
 * [cts](cts.md) - Supports testing repository connectors using our Conformance Test Suite. Can be configured to support other repositories via simple values.
 * [pts](pts.md) - Performance test suite to aid in measuring the performance of repository connectors.
 
-# Caveat: Strimzi: permissions and co-existance
+## Caveat: Strimzi: permissions and co-existance
 
 When any of the above charts are deployed, they include the install of the Strimzi operator (for kafka). However Strimzi deploys some cluster-scoped resources which has two implications:
 
-* Admin level to the cluster permissions are needed - since cluster resources need to be deployed. Without these permissions the Charts will not work
-* As the resources are cluster-level you cannot install a second chart - or additional install of the same chart as clashes will be seen on these resources. So no testing, debug in parallel or shared k8s clusters for multiple develoeprs
+* Admin level to the cluster permissions are needed - since cluster resources need to be deployed. Without these permissions the Charts will not work.
+* As the resources are cluster-level you cannot install a second chart - or additional install of the same chart as clashes will be seen on these resources. So no testing, debug in parallel or shared k8s clusters for multiple developers.
 
 To address this, the charts all have the option to NOT install Strimzi. If this is done
 * You can install multiple charts (recommended 1 per namespace) for the same, or different, user.
-* You do not need such high permissions to install the Egeria chart
+* You do not need such high permissions to install the Egeria chart.
 
 To skip the install add the following to the install: `--set strimzi.enabled=false` ie:
 ```
 helm install base egeria-base --set strimzi.enabled=false
 ```
 
-You DO need Strimzi already installed by an admin
+You DO need Strimzi already installed by an admin:
+
 * See Strimzi docs for information for [installing Strimzi via Helm](https://strimzi.io/blog/2018/11/01/using-helm/) or alternatively install another way, such as via the operator catalog.
-* Ensure the strimzi operator is configured to [watch all namespaces](https://strimzi.io/docs/operators/latest/full/configuring.html#deploying-cluster-operator-to-watch-whole-cluster-str) (or at least includes the ones you want to use)
+* Ensure the strimzi operator is configured to [watch all namespaces](https://strimzi.io/docs/operators/latest/full/configuring.html#deploying-cluster-operator-to-watch-whole-cluster-str) (or at least includes the ones you want to use).
 
 ---8<-- "snippets/abbr.md"

--- a/site/docs/guides/operations/kubernetes/index.md
+++ b/site/docs/guides/operations/kubernetes/index.md
@@ -7,8 +7,7 @@ Kubernetes offers one standard way of deploying the Egeria platform into a varie
 
 - [Introduction to Kubernetes](k8s.md)
 - [Introduction to Helm](helm.md)
-- [Sample chart - the Coco Pharmaceuticals lab](charts/lab.md)
-- [Sample chart - base egeria setup](charts/base.md)
+- [Egeria charts](charts/overview)
 - [Container images](container-images.md)
 - [Developing a custom deployment](custom-deployment.md)
 - [Egeria Operator](operator.md)

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
               - Useful Kubernetes commands: guides/operations/kubernetes/k8s-cmds.md
               - Introduction to Helm: guides/operations/kubernetes/helm.md
               - Charts:
+                  - Egeria Chart overview: guides/operations/kubernetes/charts/overview.md
                   - Base Egeria Chart: guides/operations/kubernetes/charts/base.md
                   - Coco Pharmaceuticals Lab: guides/operations/kubernetes/charts/lab.md
                   - CTS Chart: guides/operations/kubernetes/charts/cts.md


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Adds documentation on how to install multiple versions of egeria helm charts within a k8s cluster
- requires https://github.com/odpi/egeria-charts/issues/117 which added support to skip the embedded strimzi install so that it can be done manually
Also allows install with reduced permissions
Minor refactor to create a new chart summary