### PR TITLE
#508 add type changes back into 3.11 release notes

### DIFF
--- a/site/docs/release-notes/3-11.md
+++ b/site/docs/release-notes/3-11.md
@@ -51,7 +51,7 @@
 ??? functional "Open Metadata Types"
 
     * The **ProfileLocation** relationship between **ActorProfile** and **Location** has been added to model [0110 Actors](/types/1/0110-Actors).
-    * The **AssignmentScope** relationship between two **Referenceable** entities has been added to model [0120 Assignment Scopes](/types/1/0120-Assignment-Scopes).  The [ProjectScope](/types/1/130-Projects) and [GovernanceRoleAssignment](/types/4/0445-Governance-Roles) relationships are deprecated in favour of this new relationship.
+    * The **AssignmentScope** relationship between two **Referenceable** entities has been added to model [0120 Assignment Scopes](/types/1/0120-Assignment-Scopes).  The [ProjectScope](/types/1/0130-Projects) and [GovernanceRoleAssignment](/types/4/0445-Governance-Roles) relationships are deprecated in favour of this new relationship.
     * New parameters `stewardTypeName` and `stewardPropertyName` have been added to the **ValidValuesMapping** and **ReferenceValueAssignment** relationships to allow the steward to be represented by a UserIdentity, a PersonRole or an ActorProfile.  See model [0545](/types/5/0545-Reference-Data).
     * The [**ValidValuesImplementation**](/types/5/0545-Reference-Data) becomes a multi-link relationship.
     * The *status* attribute on [*Project*](/types/1/0130-Projects) is deprecated in favour of the more specific *projectStatus* attribute, which makes it easier to align with an appropriate valid value set.

--- a/site/docs/release-notes/3-11.md
+++ b/site/docs/release-notes/3-11.md
@@ -48,6 +48,19 @@
 
     This is now fixed.
 
+??? functional "Open Metadata Types"
+
+    * The **ProfileLocation** relationship between **ActorProfile** and **Location** has been added to model [0110 Actors](/types/1/0110-Actors).
+    * The **AssignmentScope** relationship between two **Referenceable** entities has been added to model [0120 Assignment Scopes](/types/1/0120-Assignment-Scopes).  The [ProjectScope](/types/1/130-Projects) and [GovernanceRoleAssignment](/types/4/0445-Governance-Roles) relationships are deprecated in favour of this new relationship.
+    * New parameters `stewardTypeName` and `stewardPropertyName` have been added to the **ValidValuesMapping** and **ReferenceValueAssignment** relationships to allow the steward to be represented by a UserIdentity, a PersonRole or an ActorProfile.  See model [0545](/types/5/0545-Reference-Data).
+    * The [**ValidValuesImplementation**](/types/5/0545-Reference-Data) becomes a multi-link relationship.
+    * The *status* attribute on [*Project*](/types/1/0130-Projects) is deprecated in favour of the more specific *projectStatus* attribute, which makes it easier to align with an appropriate valid value set.
+    * New parameters `name` and `contactType` have been added to the **ContactDetails** entity to allow more detail about a contact method to be captured.  See model [0110](/types/1/0110-Actors).
+    * New parameter `pronouns` has been added to the **Person** entity to capture an individual's pronoun preferences.  See model [0112](/types/1/0112-People).
+    * New parameter `identifier` has been added to the **Team** entity to capture code identifers allocated to teams.  See model [0115](/types/1/0115-Teams).
+    * A new relationship called **Stakeholder** has been added to link ActorProfiles with Referenceables.  See model [0130](/types/1/0130-Projects).
+    * The *BusinessCapabilityControls* relationship is deprecated in favour of the more generic [*GovernanceDefinitionScope*](/types/4/0401-Governance-Definitions).
+
 ??? functional "Additional HTTP headers can now be passed to security plugins"
 
     Additional HTTP headers can now be passed to security plugins, and will also be propogated on federated queries


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Adds back type changes accidentally removed when editing 3.11 release notes
* corrects bad links