### PR TITLE
#528 unset navigation.instant to allow anchors to work in Safari

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -831,7 +831,6 @@ theme:
   language: en
   custom_dir: overrides
   features:
-    - navigation.instant
     - navigation.tabs
     - navigation.sections
     - navigation.top


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

This PR unsets 'navigation.instant' to fix an issue whereby anchors within the docs do not work in Safari.

Fixes #528

Issue has further details on the problem & fix.

Not anticipating any noticeable change

Tested with a local mkdocs build & Safari+STN as well as chrome/firefox