### PR TITLE
Corrected version errors in 3.12 release notes

### DIFF
--- a/site/docs/release-notes/3-12.md
+++ b/site/docs/release-notes/3-12.md
@@ -3,8 +3,6 @@
 
 # Release 3.12 (October 2022)
 
-**These docs are currently under development for this release**
-
 ??? warning "Known Issues"
 
     This section highlights any significant issues to be aware of. Refer to our [GitHub Issues](https://github.com/odpi/egeria/issues) for a full list of open issues or to open a new one.
@@ -61,16 +59,16 @@
          * Strimzi 0.31.1 with Kafka 3.2.2
 
 
-    ??? info "Base Chart for 3.10"
+    ??? info "Base Chart for 3.12"
 
-         The Egeria base chart 3.10.0 has been updated to include:
+         The Egeria base chart 3.12.0 has been updated to include:
 
          * Egeria 3.12
          * Egeria Ecosystem UI 3.8.0
          * Strimzi 0.31.1 with Kafka 3.2.2
 
 
-    ??? info "CTS & PTS Charts for 3.10"
+    ??? info "CTS & PTS Charts for 3.12"
 
          * Egeria 3.12
          * Strimzi 0.31.1 with Kafka 3.2.2


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* Removed reference to the 3.12 release notes being in development
* Corrected typo on chart versions which still listed 3.10 instead of 3.12