### PR TITLE
#653 pin mkdocs to 8.5.3

### DIFF
--- a/.github/workflows/merge-mkdocs.yml
+++ b/.github/workflows/merge-mkdocs.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==8.5.3
       - run: mkdocs gh-deploy --force
         working-directory: ./site

--- a/.github/workflows/pr-mkdocs.yml
+++ b/.github/workflows/pr-mkdocs.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==8.5.3
       - run: mkdocs build 
         working-directory: ./site


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

Pin mkdocs-material to 8.5.3, as 9.0.0 appears to break the build of our docs.

See #853 for further info, including following up any necessary reports  back to mkdocs-material or changes we have to be make to be compatible with ongoing versions