### PR TITLE
#659 re-merge custom header for page title display

### DIFF
--- a/.github/workflows/merge-mkdocs.yml
+++ b/.github/workflows/merge-mkdocs.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material==8.5.3
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force
         working-directory: ./site

--- a/.github/workflows/pr-mkdocs.yml
+++ b/.github/workflows/pr-mkdocs.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material==8.5.3
+      - run: pip install mkdocs-material
       - run: mkdocs build 
         working-directory: ./site

--- a/site/overrides/partials/header.html
+++ b/site/overrides/partials/header.html
@@ -1,16 +1,16 @@
-<!-- SPDX-License-Identifier: CC-BY-4.0 -->
-<!-- Copyright Contributors to the Egeria project. -->
-
 <!--
-  Copyright (c) 2016-2021 Martin Donath <martin.donath@squidfunk.com>
+  Copyright (c) 2016-2023 Martin Donath <martin.donath@squidfunk.com>
+
   Permission is hereby granted, free of charge, to any person obtaining a copy
   of this software and associated documentation files (the "Software"), to
   deal in the Software without restriction, including without limitation the
   rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
   sell copies of the Software, and to permit persons to whom the Software is
   furnished to do so, subject to the following conditions:
+
   The above copyright notice and this permission notice shall be included in
   all copies or substantial portions of the Software.
+
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
   FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,133 +20,135 @@
   IN THE SOFTWARE.
 -->
 
+<!-- Determine base classes -->
+{% set class = "md-header" %}
+{% if "navigation.tabs.sticky" in features %}
+  {% set class = class ~ " md-header--lifted" %}
+{% endif %}
+
 <!-- Header -->
-<header class="md-header" data-md-component="header">
-    <nav
-            class="md-header__inner md-grid"
-            aria-label="{{ lang.t('header.title') }}"
+<header class="{{ class }}" data-md-component="header">
+  <nav
+    class="md-header__inner md-grid"
+    aria-label="{{ lang.t('header') }}"
+  >
+
+    <!-- Link to home -->
+    <a
+      href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
+      title="{{ config.site_name | e }}"
+      class="md-header__button md-logo"
+      aria-label="{{ config.site_name }}"
+      data-md-component="logo"
     >
+      {% include "partials/logo.html" %}
+    </a>
 
-        <!-- Button to open drawer -->
-        <label class="md-header__button md-icon" for="__drawer">
-            {% include ".icons/material/menu" ~ ".svg" %}
-        </label>
+    <!-- Button to open drawer -->
+    <label class="md-header__button md-icon" for="__drawer">
+      {% include ".icons/material/menu" ~ ".svg" %}
+    </label>
 
-        <!-- Link to home -->
-        <a
-                href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}"
-                title="{{ config.site_name | e }}"
-                class="md-header__button md-logo"
-                aria-label="{{ config.site_name }}"
-                data-md-component="logo"
-        >
-            {% include "partials/logo.html" %}
-        </a>
-
-        <!-- Header title -->
-        <div class="md-header__title" data-md-component="header-title">
-            <div class="md-header__ellipsis">
-                <div class="md-header__topic">
-                    <span class="md-ellipsis">
-                        {% if page and page.meta and page.meta.title %}
-                            {{ page.meta.title }}
-                        {% else %}
-                            {{ page.title }}
-                        {% endif %}
-                    </span>
-                </div>
-                <div class="md-header__topic" data-md-component="header-topic">
-                    <span class="md-ellipsis">
-                        {% if page and page.meta and page.meta.title %}
-                            {{ page.meta.title }}
-                        {% else %}
-                            {{ page.title }}
-                        {% endif %}
-                    </span>
-                </div>
-            </div>
-        </div>
-
-        <!-- Color palette -->
-        {% if not config.theme.palette is mapping %}
-        <form class="md-header__option" data-md-component="palette">
-            {% for option in config.theme.palette %}
-            {% set primary = option.primary | replace(" ", "-") | lower %}
-            {% set accent  = option.accent  | replace(" ", "-") | lower %}
-            <input
-                    class="md-option"
-                    data-md-color-media="{{ option.media }}"
-                    data-md-color-scheme="{{ option.scheme }}"
-                    data-md-color-primary="{{ primary }}"
-                    data-md-color-accent="{{ accent }}"
-                    {% if option.toggle %}
-                    aria-label="{{ option.toggle.name }}"
-                    {% else  %}
-                    aria-hidden="true"
-                    {% endif %}
-                    type="radio"
-                    name="__palette"
-                    id="__palette_{{ loop.index }}"
-            />
-            {% if option.toggle %}
-            <label
-                    class="md-header__button md-icon"
-                    title="{{ option.toggle.name }}"
-                    for="__palette_{{ loop.index0 or loop.length }}"
-                    hidden
-            >
-                {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
-            </label>
+    <!-- Header title -->
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic" data-md-component="header-topic">
+          <span class="md-ellipsis">
+            {% if page.meta and page.meta.title %}
+              {{ page.meta.title }}
+            {% else %}
+              {{ page.title }}
             {% endif %}
-            {% endfor %}
-        </form>
-        {% endif %}
-
-        <!-- Site language selector -->
-        {% if config.extra.alternate %}
-        <div class="md-header__option"></form>
-            <div class="md-select">
-                {% set icon = config.theme.icon.alternate or "material/translate" %}
-                <button
-                        class="md-header__button md-icon"
-                        aria-label="{{ lang.t('select.language.title') }}"
-                >
-                    {% include ".icons/" ~ icon ~ ".svg" %}
-                </button>
-                <div class="md-select__inner">
-                    <ul class="md-select__list">
-                        {% for alt in config.extra.alternate %}
-                        <li class="md-select__item">
-                            <a
-                                    href="{{ alt.link | url }}"
-                                    hreflang="{{ alt.lang }}"
-                                    class="md-select__link"
-                            >
-                                {{ alt.name }}
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-            </div>
         </div>
-        {% endif %}
+      </div>
+    </div>
 
-        <!-- Button to open search modal -->
-        {% if "search" in config["plugins"] %}
-        <label class="md-header__button md-icon" for="__search">
-            {% include ".icons/material/magnify.svg" %}
-        </label>
+    <!-- Color palette -->
+    {% if not config.theme.palette is mapping %}
+      <form class="md-header__option" data-md-component="palette">
+        {% for option in config.theme.palette %}
+          {% set scheme = option.scheme | d("default", true) %}
+          <input
+            class="md-option"
+            data-md-color-media="{{ option.media }}"
+            data-md-color-scheme="{{ scheme | replace(' ', '-') }}"
+            data-md-color-primary="{{ option.primary | replace(' ', '-') }}"
+            data-md-color-accent="{{ option.accent | replace(' ', '-') }}"
+            {% if option.toggle %}
+              aria-label="{{ option.toggle.name }}"
+            {% else  %}
+              aria-hidden="true"
+            {% endif %}
+            type="radio"
+            name="__palette"
+            id="__palette_{{ loop.index }}"
+          />
+          {% if option.toggle %}
+            <label
+              class="md-header__button md-icon"
+              title="{{ option.toggle.name }}"
+              for="__palette_{{ loop.index0 or loop.length }}"
+              hidden
+            >
+              {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+            </label>
+          {% endif %}
+        {% endfor %}
+      </form>
+    {% endif %}
 
-        <!-- Search interface -->
-        {% include "partials/search.html" %}
-        {% endif %}
-
-        <!-- Repository information -->
-        {% if config.repo_url %}
-        <div class="md-header__source">
-            {% include "partials/source.html" %}
+    <!-- Site language selector -->
+    {% if config.extra.alternate %}
+      <div class="md-header__option"></form>
+        <div class="md-select">
+          {% set icon = config.theme.icon.alternate or "material/translate" %}
+          <button
+            class="md-header__button md-icon"
+            aria-label="{{ lang.t('select.language') }}"
+          >
+            {% include ".icons/" ~ icon ~ ".svg" %}
+          </button>
+          <div class="md-select__inner">
+            <ul class="md-select__list">
+              {% for alt in config.extra.alternate %}
+                <li class="md-select__item">
+                  <a
+                    href="{{ alt.link | url }}"
+                    hreflang="{{ alt.lang }}"
+                    class="md-select__link"
+                  >
+                    {{ alt.name }}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
         </div>
-        {% endif %}
-    </nav>
+      </div>
+    {% endif %}
+
+    <!-- Button to open search modal -->
+    {% if "material/search" in config.plugins %}
+      <label class="md-header__button md-icon" for="__search">
+        {% include ".icons/material/magnify.svg" %}
+      </label>
+
+      <!-- Search interface -->
+      {% include "partials/search.html" %}
+    {% endif %}
+
+    <!-- Repository information -->
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+  </nav>
+
+  <!-- Navigation tabs (sticky) -->
+  {% if "navigation.tabs.sticky" in features %}
+    {% if "navigation.tabs" in features %}
+      {% include "partials/tabs.html" %}
+    {% endif %}
+  {% endif %}
 </header>


### PR DESCRIPTION
Signed-off-by: Nigel Jones <nigel.l.jones+git@gmail.com>

* mkdocs-material 9.x broke with our overrides/partials/header.html
* the default headers worked ok - ie for search - but does not correctly show our page title
* re-applied a tweak to the page title section based on latest default header
* Local test now shows page working correctly
* Should fix issues with other optional features too (for v9)
* Future updates may cause a similar issue