### PR TITLE
Use gradle distribution

### DIFF
--- a/site/docs/education/egeria-dojo/developer/overview.md
+++ b/site/docs/education/egeria-dojo/developer/overview.md
@@ -63,6 +63,7 @@ This dojo was last tested using Egeria release 3.14.
     These next steps build the Egeria platform and then install it ready for the dojo.
     
     ??? tip "Build Egeria's OMAGServerPlatform"
+
         From a command window, use the `pwd` command to make sure you are in the `../egeria-main-libraries/egeria` directory created when you cloned the `egeria.git` repository.
         
         ```bash
@@ -70,6 +71,23 @@ This dojo was last tested using Egeria release 3.14.
         /Users/mandy-chessell/egeria-main-libraries/egeria
         $
         ```
+
+        ???+ tip "Release 3.14 and before - patch Egeria's build"
+            Open the build file that creates the distribution:
+            ```bash
+            vi open-metadata-distribution/open-metadata-assemblies/build.gradle
+            ```
+            Scroll down the file until you find the following two lines (lines 184-185):
+            ```bash
+                    include 'content-packs'
+                    include 'sample-data'
+            ```
+            Press the `i` key to enter INSERT mode.  Using the arrow keys to move to the end of the lines, update the path names to the following values and then press the `ESC` key.
+            ```bash
+                    include 'content-packs/*'
+                    include 'sample-data/*/*'
+            ```
+            Enter `:wq` to save and quit the file.
 
         Enter the following command to build the egeria libraries:
 

--- a/site/docs/education/tutorials/building-egeria-tutorial/task-building-egeria-source.md
+++ b/site/docs/education/tutorials/building-egeria-tutorial/task-building-egeria-source.md
@@ -70,9 +70,9 @@ The build scripts that use these technologies ensure the software is built in th
 
     Our direction is for a Gradle build to replace Maven; however, [that work is still underway :material-dock-window:](https://github.com/odpi/egeria/issues/3370){ target=gh }. As such, you may still find git repositories that use [Maven](#building-with-maven).
 
-As of release 3.0, most egeria.git components are building with gradle, but artifacts are not being created, and verification has not been done.   Release 4.0 is when we expect to complete the transition.
+    As of release 3.0, most egeria.git components are building with gradle, but artifacts are not being created, and verification has not been done.   Release 4.0 is when we expect to complete the transition.
 
-Contributions to this work are welcome, as are issue reports!   If you'd like to help complete this transition, see [odpi/egeria#3370](https://github.com/odpi/egeria/issues/3370){ target=gh }
+    Contributions to this work are welcome, as are issue reports!   If you'd like to help complete this transition, see [odpi/egeria#3370](https://github.com/odpi/egeria/issues/3370){ target=gh }
 
 ##### Building with Maven
 

--- a/site/docs/education/tutorials/building-egeria-tutorial/terminal-installing-egeria.md
+++ b/site/docs/education/tutorials/building-egeria-tutorial/terminal-installing-egeria.md
@@ -2,7 +2,6 @@
 <!-- Copyright Contributors to the ODPi Egeria project. -->
 
 
-
 The [egeria build process](/education/tutorials/building-egeria-tutorial/overview) creates the distribution files for Egeria in the `open-metadata-distribution` module.   To see its contents, after a full gradle build completes, use the following `cd` command to change to its `build/distributions` directory:
 
 ```bash
@@ -36,7 +35,7 @@ cd ~/egeria-install
 It is now possible to unpack the tar file with the following steps.
 
 ```bash
-gunzip -xf egeria*-distribution.tar.gz
+gunzip egeria*-distribution.tar.gz
 ```
 ```bash
 tar -xf egeria*-distribution.tar
@@ -44,7 +43,7 @@ tar -xf egeria*-distribution.tar
 A new directory is created called `{{release}}-distribution.tar.gz` or `egeria-3.14-distribution.tar.gz` in this example.  Change to this new directory and list its contents as shown below.
 
 ```bash
-cd egeria-omag*
+cd egeria*gz
 ```
 ```bash
 ls
@@ -104,4 +103,32 @@ spring-rest-client-connector-3.14.jar
 
 Copy the jar files for any additional connectors you want to use into the `lib` directory.  The connectors available for Egeria are listed in the [Connector Catalog](/connectors).
 
+The `content-packs` directory contains [Open Metadata Archives](/concepts/open-metadata-archive) that provide sample open metadata content.  The `README.md` describes their content.
+```bash
+ls content-packs
+```
+```bash
+CloudInformationModel.json			DataStoreConnectorTypes.json
+CocoBusinessSystemsArchive.json			OpenConnectorsArchive.json
+CocoClinicalTrialsTemplatesArchive.json		OpenMetadataTypes.json
+CocoComboArchive.json				README.md
+CocoGovernanceEngineDefinitionsArchive.json	SimpleAPICatalog.json
+CocoGovernanceProgramArchive.json		SimpleDataCatalog.json
+CocoOrganizationArchive.json			SimpleEventCatalog.json
+CocoSustainabilityArchive.json			SimpleGovernanceCatalog.json
+CocoTypesArchive.json
+```
+The `sample-data` directory contains sample data that is used in various labs and samples.
+```bash
+ls sample-data/*
+```
+```bash
+sample-data/oak-dene-drop-foot-weekly-measurements:
+week1.csv	week3.csv	week5.csv	week7.csv	week9.csv
+week2.csv	week4.csv	week6.csv	week8.csv
+
+sample-data/old-market-drop-foot-weekly-measurements:
+week1.csv	week3.csv	week5.csv	week7.csv	week9.csv
+week2.csv	week4.csv	week6.csv	week8.csv
+```
 --8<-- "snippets/abbr.md"


### PR DESCRIPTION
Signed-off-by: Mandy Chessell <mandy.e.chessell@gmail.com>

The egeria.git issue https://github.com/odpi/egeria/issues/7310 describes the differences between the maven and gradle distribution files.  These updates allow the developer dojo to make use of the distribution from the gradle build.