### PR TITLE
Fix formatting in admin guide

### DIFF
--- a/site/docs/guides/admin/servers/configuring-a-conformance-test-server.md
+++ b/site/docs/guides/admin/servers/configuring-a-conformance-test-server.md
@@ -5,21 +5,25 @@
 
 A *Conformance Test Server* is configured by creating a [configuration document](/concepts/configuration-document).  Below is the outline structure of the server's configuration document.
 
-
 ![Configuration for a conformance test server](conformance-suite-config.svg)
 
---8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+??? info "Configuring the default values used in subsequent configuration commands"
+    --8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+    --8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
+??? info "Registering the server with a cohort"
+    --8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
 
---8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-workbenches.md"
+??? info "Configuring the test workbenches"
+    --8<-- "docs/guides/admin/servers/configuring-the-workbenches.md"
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-a-data-engine-proxy-server.md
+++ b/site/docs/guides/admin/servers/configuring-a-data-engine-proxy-server.md
@@ -6,65 +6,65 @@
 
 ## Overview 
 
-Each [type of OMAG Server](/concepts/omag-server/#types-of-omag-server) is configured by creating
-a [configuration document](/concepts/configuration-document). 
-
-For data engine proxy server, following can be configured:
+Each [type of OMAG Server](/concepts/omag-server/#types-of-omag-server) is configured by creating a [configuration document](/concepts/configuration-document). For data engine proxy server, following can be configured:
 
 ![Configuration for an data engine proxy server](data-engine-proxy-config.svg)
 
---8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
-<!-- --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md" -->
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
-## Configuring Date Engine Proxy Services 
-
-???+ intermediate "Course-grained helper command"
-    !!! post "POST - Configure Date Engine Proxy Services"
-        ```
-        {{serverURLRoot}}/open-metadata/admin-services/users/{{userId}}/servers/{{serverName}}/data-engine-proxy-service/configuration
+??? info "Configuring the Data Engine Proxy Services"
+    ## Configuring Data Engine Proxy Services 
     
-        ```
+    ???+ intermediate "Course-grained helper command"
+        !!! post "POST - Configure Date Engine Proxy Services"
+            ```
+            {{serverURLRoot}}/open-metadata/admin-services/users/{{userId}}/servers/{{serverName}}/data-engine-proxy-service/configuration
+        
+            ```
+        
+            ```json
+            {
+                "class": "DataEngineProxyConfig",
+                "accessServiceRootURL": "{{{metadata-server-platform-url}}}",
+                "accessServiceServerName": "{{metadata-server-name}}",
+                "dataEngineConnection": {
+                    "class": "Connection",
+                    "connectorType": {
+                        "class": "ConnectorType",
+                        "connectorProviderClassName": "org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.DataStageConnectorProvider"
+                    },
+                    "endpoint": {
+                        "class": "Endpoint",
+                        "address": "{{data-engine-endpoint}}",
+                        "protocol": "https"
+                    },
+                    "userId": "{{data-engine-user}}",
+                    "clearPassword": "{{data-engine-password}}"
+                },
+                "pollIntervalInSeconds": 60
+            }
+            ```
+    #### Configuration Reference
     
-        ```json
-        {
-            "class": "DataEngineProxyConfig",
-            "accessServiceRootURL": "{{{metadata-server-platform-url}}}",
-            "accessServiceServerName": "{{metadata-server-name}}",
-            "dataEngineConnection": {
-                "class": "Connection",
-                "connectorType": {
-                    "class": "ConnectorType",
-                    "connectorProviderClassName": "org.odpi.egeria.connectors.ibm.datastage.dataengineconnector.DataStageConnectorProvider"
-                },
-                "endpoint": {
-                    "class": "Endpoint",
-                    "address": "{{data-engine-endpoint}}",
-                    "protocol": "https"
-                },
-                "userId": "{{data-engine-user}}",
-                "clearPassword": "{{data-engine-password}}"
-            },
-            "pollIntervalInSeconds": 60
-        }
-        ```
-#### Configuration Reference
-
-| Property               | Description | Is mandatory |
-|------------------------|---|---|
-| dataEngineConnection   | OCF connection configuration object that defines the connector type and its properties. Refer to specific connector for detailed reference. Example provided for [IBM Data Stage connector](https://github.com/odpi/egeria-connector-ibm-information-server/tree/main/datastage-adapter).  | Yes |
-|  pollIntervalInSeconds | The polling interval in seconds to call the sequence extracting metadata. | Yes | 
-
-#### Removing the Data Engine Services from the server configuration
-
-???+ intermediate "Course-grained helper command"
-    !!! delete  "DELETE - Remove Data Engine Configuration from the server"
-        ```
-        {{serverURLRoot}}/open-metadata/admin-services/users/{{userId}}/servers/{{serverName}}/data-engine-proxy-service/configuration
-        ```
-
+    | Property               | Description | Is mandatory |
+    |------------------------|---|---|
+    | dataEngineConnection   | OCF connection configuration object that defines the connector type and its properties. Refer to specific connector for detailed reference. Example provided for [IBM Data Stage connector](https://github.com/odpi/egeria-connector-ibm-information-server/tree/main/datastage-adapter).  | Yes |
+    |  pollIntervalInSeconds | The polling interval in seconds to call the sequence extracting metadata. | Yes | 
+    
+    #### Removing the Data Engine Services from the server configuration
+    
+    ???+ intermediate "Course-grained helper command"
+        !!! delete  "DELETE - Remove Data Engine Configuration from the server"
+            ```
+            {{serverURLRoot}}/open-metadata/admin-services/users/{{userId}}/servers/{{serverName}}/data-engine-proxy-service/configuration
+            ```
+    
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-a-metadata-access-point.md
+++ b/site/docs/guides/admin/servers/configuring-a-metadata-access-point.md
@@ -9,18 +9,23 @@ For a metadata access point, the following can be configured:
 
 ![Configuration document for a metadata access point](metadata-access-point-config.svg)
 
---8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+??? info "Configuring the default values used in subsequent configuration commands"
+    --8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+    --8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
+??? info "Registering the server with a cohort"
+    --8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
 
---8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-access-services.md"
+??? info "Configuring the access services"
+    --8<-- "docs/guides/admin/servers/configuring-the-access-services.md"
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-a-metadata-access-store.md
+++ b/site/docs/guides/admin/servers/configuring-a-metadata-access-store.md
@@ -9,27 +9,33 @@ A metadata access store can be run standalone, without connecting to a cohort:
 
 ![Standalone metadata access store](standalone-metadata-access-store-config.svg)
 
-Adding the cohort configuration enables the metadata server to communicate with other metadata
-servers:
+Adding the cohort configuration enables the metadata server to communicate with other metadata servers:
 
 ![Connected metadata access store](connected-metadata-access-store-config.svg)
 
---8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+??? info "Configuring the default values used in subsequent configuration commands"
+    --8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+    --8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
+??? info "Configuring the local repository store"
+    --8<-- "docs/guides/admin/servers/configuring-the-local-repository.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-local-repository.md"
+??? info "Registering the server with a cohort"
+    --8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
 
---8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
+??? info "Configuring the access services"
+    --8<-- "docs/guides/admin/servers/configuring-the-access-services.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-startup-archives.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-access-services.md"
+??? info "(Optional) Configuring the open metadata archives to load on server start up"
+    --8<-- "docs/guides/admin/servers/configuring-the-startup-archives.md"
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-a-repository-proxy.md
+++ b/site/docs/guides/admin/servers/configuring-a-repository-proxy.md
@@ -7,130 +7,24 @@ A *Repository Proxy* is configured by creating a [configuration document](/conce
 
 ![Configuration for a repository proxy](repository-proxy-configuration.svg)
 
---8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+??? info "Configuring the default values used in subsequent configuration commands"
+    --8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+    --8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
+??? info "Registering the server with a cohort"
+    --8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
 
---8<-- "docs/guides/admin/servers/configuring-registration-to-a-cohort.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-startup-archives.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-repository-proxy-connector.md"
-
-## Configure the connectors to the third party metadata repository
-
-The mapping between a third party metadata repository and the open metadata protocols in a [repository proxy](/concepts/repository-proxy) is implemented by two connectors:
-
-- A [repository connector](/concepts/repository-connector)
-- A [event mapper connector](/concepts/event-mapper-connector)
-
-They are configured as follows.
-
-### Configure the repository connector
-
-The repository proxy can act as a proxy to a third party metadata repository. This is done by adding the connection for the [repository connector](/concepts/repository-connector) as follows.
-
-!!! post "POST - configure the repository connector"
-```
-{{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/local-repository/mode/repository-proxy/connection
-```
-
-!!! post "POST - configure an embedded local repository"
-```
-{{baseURL}}/open-metadata/admin-services/users/{{user}}/servers/{{server}}/local-repository/mode/repository-proxy/connection
-```
-
-with the body defining a VirtualConnection, 
-
-for example , using an in memory local repository
-```
-{
-    "class": "VirtualConnection",
-    "headerVersion": 0,
-    "displayName": "OMRS Hive Metastore Repository Connector",
-    "connectorType": {
-        "class": "ConnectorType",
-        "headerVersion": 0,
-        "type": {
-            "class": "ElementType",
-            "headerVersion": 0,
-            "elementOrigin": "LOCAL_COHORT",
-            "elementVersion": 0,
-            "elementTypeId": "954421eb-33a6-462d-a8ca-b5709a1bd0d4",
-            "elementTypeName": "ConnectorType",
-            "elementTypeVersion": 1,
-            "elementTypeDescription": "A set of properties describing a type of connector."
-        },
-        "guid": "bcdb3e04-b545-4001-b9e7-0305a4c21c1c",
-        "qualifiedName": "OMRS Hive Metastore Repository Connector",
-        "displayName": "OMRS Hive Metastore Repository Connector",
-        "description": "OMRS Hive Metastore Repository Connector that issues calls to Hive Metastore",
-        "connectorProviderClassName":"org.odpi.egeria.connectors.hms.repositoryconnector.CachingOMRSRepositoryProxyConnectorProvider"
-   },
-   "embeddedConnections":[
-      {
-         "class":"EmbeddedConnection",
-         "headerVersion":0,
-         "position":0,
-         "displayName":"embedded in memory",
-         "embeddedConnection":{
-            "class":"Connection",
-            "headerVersion":0,
-            "connectorType":{
-               "class":"ConnectorType",
-               "headerVersion":0,
-               "type":{
-                  "class":"ElementType",
-                  "headerVersion":0,
-                  "elementOrigin":"LOCAL_COHORT",
-                  "elementVersion":0,
-                  "elementTypeId":"954421eb-33a6-462d-a8ca-b5709a1bd0d4",
-                  "elementTypeName":"ConnectorType",
-                  "elementTypeVersion":1,
-                  "elementTypeDescription":"A set of properties describing a type of connector."
-               },
-               "guid":"65cc9091-757f-4bcd-b937-426160be8bc2",
-               "qualifiedName":"Egeria:OMRSRepositoryConnector:InMemory",
-               "displayName":"In Memory OMRS Repository Connector",
-               "description":"Native open metadata repository connector that maps open metadata calls to a set of in memory hash maps - demo use only.",
-               "connectorProviderClassName":"org.odpi.openmetadata.adapters.repositoryservices.inmemory.repositoryconnector.InMemoryOMRSRepositoryConnectorProvider"
-            }
-         }
-      }
-   ]
-}
-
-```
-
-
-The request body should be the connection option to use for configuring the connector,
-which can include any connector-specific options as well as general details like the 
-endpoint and credentials for the third party repository.
-
-
-### Configure the event mapper connector
-
-Any open metadata repository that supports its own API **must** also implement an event mapper to ensure the [Open Metadata Repository Services (OMRS)](/services/omrs) is notified when metadata is added to the repository without going through the open metadata APIs.
-
-The [event mapper is a connector](/concepts/event-mapper-connector) that listens for proprietary events from the repository and converts them into calls to the OMRS. The OMRS then distributes this new metadata.
-
-!!! post "POST - configure event mapper"
-```
-{{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/local-repository/event-mapper-details?connectorProvider={{fullyQualifiedJavaClassName}}&eventSource={{resourceName}}
-```
-
-    The `connectorProvider` should be set to the fully-qualified Java class name for the [connector provider](/concepts/connector-provider), and the `eventSource` should give the details for how to access the events (for example, the hostname and port number of an Apache Kafka bootstrap server).
-
-
-
-
-
+??? info "Configuring the connectors to the third party metadata repository"
+    --8<-- "docs/guides/admin/servers/configuring-the-repository-proxy-connector.md"
 
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-a-view-server.md
+++ b/site/docs/guides/admin/servers/configuring-a-view-server.md
@@ -7,12 +7,16 @@ A *View Server* is configured by creating a [configuration document](/concepts/c
 
 ![Configuration for a view server](view-server-config.svg)
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-view-services.md"
+??? info "Configuring the view services"
+    --8<-- "docs/guides/admin/servers/configuring-the-view-services.md"
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-an-engine-host.md
+++ b/site/docs/guides/admin/servers/configuring-an-engine-host.md
@@ -7,8 +7,22 @@ An *Engine Host* is configured by creating a [configuration document](/concepts/
 
 ![Configuration for an engine host](engine-host-config.svg)
 
-??? example "Example configuration of a minimal engine host server"
-    Below is an example of the configuration for a minimal engine host server. It has a single engine service (`Asset Analysis OMES`) and the default audit log. Both the Governance Engine OMAS used by the engine host services and the Discovery Engine OMAS used by the Asset Analysis OMES are running on the metadata server called `myMetadataServer`.
+The configuration document is built up using a series of administration calls:
+
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
+
+??? info "Configuring the engine host services"
+    --8<-- "docs/guides/admin/servers/configuring-the-engine-host-services.md"
+
+??? example "Example configuration of an engine host"
+    This is an example of the configuration for an engine host. It has a single engine service ([Asset Analysis OMES](/services/omes/asset-analysis/overview)) and the default audit log. Both the [Governance Engine OMAS](/services/omas/governance-engine/overview) used by the engine host services and the [Discovery Engine OMAS](/services/omas/discovery-engine/overview) used by the Asset Analysis OMES are running on the metadata access server called `myserver`.
 
     ```json
     {
@@ -101,15 +115,5 @@ An *Engine Host* is configured by creating a [configuration document](/concepts/
     }
     ```
 
-The configuration document is built up using a series of administration calls:
-
-
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
-
---8<-- "docs/guides/admin/servers/configuring-the-engine-host-services.md"
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-an-integration-daemon.md
+++ b/site/docs/guides/admin/servers/configuring-an-integration-daemon.md
@@ -26,10 +26,10 @@ An *Integration Daemon* is configured by creating a [configuration document](/co
 
     Both approaches can be used in the same integration daemon instance.  However, each integration connector to run should only be configured by
 
-    ??? info "Configuring integration services
+    ??? info "Configuring integration services"
         --8<-- "docs/guides/admin/servers/configuring-the-integration-services.md"
     
-    ??? info "Configuring integration groups
+    ??? info "Configuring integration groups"
         --8<-- "docs/guides/admin/servers/configuring-the-integration-groups.md"
 
 ??? education "Further information"

--- a/site/docs/guides/admin/servers/configuring-an-open-lineage-server.md
+++ b/site/docs/guides/admin/servers/configuring-an-open-lineage-server.md
@@ -3,8 +3,6 @@
 
 # Configuring an [open lineage server](/concepts/open-lineage-servery)
 
-## Overview
-
 Each [type of OMAG Server](/concepts/omag-server/#types-of-omag-server) is configured by creating
 a [configuration document](/concepts/configuration-document). For an open lineage server, the following can be configured:
 
@@ -15,149 +13,153 @@ a [configuration document](/concepts/configuration-document). For an open lineag
     - Audit Log Destination
     - Open Lineage Config
 
---8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
+??? info "Configuring the default values used in subsequent configuration commands"
+    --8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+    --8<-- "docs/guides/admin/servers/configuring-local-server-url.md"
 
---8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
+??? info "Configuring the basic properties"
+    --8<-- "docs/guides/admin/servers/configuring-omag-server-basic-properties.md"
 
-<!-- --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md" -->
+??? info "Configuring the audit log"
+    --8<-- "docs/guides/admin/servers/configuring-the-audit-log.md"
 
---8<-- "docs/guides/admin/servers/configuring-event-bus.md"
+??? info "Configuring the server security connector"
+    --8<-- "docs/guides/admin/servers/configuring-the-server-security-connector.md"
 
-
-## Configuring the Open Lineage Services
-
-!!! post "POST - Configure Open Lineage Services"
-    ```
-    {{serverURLRoot}}/open-metadata/admin-services/users/{{userId}}/servers/{{serverName}}/open-lineage/configuration
-    ```
-
-    ```json
-    {
-        "class": "OpenLineageConfig",
-        "openLineageDescription": "Open Lineage Service is used for the storage and querying of lineage",
-        "lineageGraphConnection": {
-            "class": "Connection",
-            "displayName": "Lineage Graph Connection",
-            "description": "Used for storing lineage in the Open Metadata format",
-            "connectorType": {
-                "class": "ConnectorType",
-                "connectorProviderClassName": "org.odpi.openmetadata.openconnectors.governancedaemonconnectors.openlineageconnectors.janusconnector.graph.LineageGraphConnectorProvider"
+??? info "Configuring the Open Lineage Services"
+    ## Configuring the Open Lineage Services
+    
+    !!! post "POST - Configure Open Lineage Services"
+        ```
+        {{serverURLRoot}}/open-metadata/admin-services/users/{{userId}}/servers/{{serverName}}/open-lineage/configuration
+        ```
+    
+        ```json
+        {
+            "class": "OpenLineageConfig",
+            "openLineageDescription": "Open Lineage Service is used for the storage and querying of lineage",
+            "lineageGraphConnection": {
+                "class": "Connection",
+                "displayName": "Lineage Graph Connection",
+                "description": "Used for storing lineage in the Open Metadata format",
+                "connectorType": {
+                    "class": "ConnectorType",
+                    "connectorProviderClassName": "org.odpi.openmetadata.openconnectors.governancedaemonconnectors.openlineageconnectors.janusconnector.graph.LineageGraphConnectorProvider"
+                },
+                "configurationProperties": {
+                    "gremlin.graph": "org.janusgraph.core.JanusGraphFactory",
+                    "storage.backend": "berkeleyje",
+                    "storage.directory": "data/servers/{{ols-server-name}}/repository/berkeley",
+                    "index.search.backend": "lucene",
+                    "index.search.directory": "data/servers/{{ols-server-name}}/repository/searchindex"
+                }
             },
-            "configurationProperties": {
-                "gremlin.graph": "org.janusgraph.core.JanusGraphFactory",
-                "storage.backend": "berkeleyje",
-                "storage.directory": "data/servers/{{ols-server-name}}/repository/berkeley",
-                "index.search.backend": "lucene",
-                "index.search.directory": "data/servers/{{ols-server-name}}/repository/searchindex"
-            }
-        },
-        "accessServiceConfig": {
-            "serverName": "{{server-name}}",
-            "serverPlatformUrlRoot": "{{server-platform-url}}",
-            "user": "admin",
-            "password": "secret"
-        },
-        "inTopicConnection": {
-            "class": "VirtualConnection",
-            "qualifiedName": "OutTopicConnector.Asset Lineage OMAS",
-            "displayName": "OutTopicConnector.Asset Lineage OMAS",
-            "description": "Client-side topic connection.",
-            "connectorType": {
-                "class": "ConnectorType",
-                "qualifiedName": "Asset Lineage Out Topic Client Connector",
-                "displayName": "Asset Lineage Out Topic Client Connector",
-                "description": "Connector supports the receipt of events on the Asset Lineage OMAS Out Topic.",
-                "connectorProviderClassName": "org.odpi.openmetadata.accessservices.assetlineage.outtopic.connector.AssetLineageOutTopicClientProvider"
+            "accessServiceConfig": {
+                "serverName": "{{server-name}}",
+                "serverPlatformUrlRoot": "{{server-platform-url}}",
+                "user": "admin",
+                "password": "secret"
             },
-            "embeddedConnections": [
-                {
-                    "class": "EmbeddedConnection",
-                    "displayName": "Topic Event Bus",
-                    "embeddedConnection": {
-                        "class": "Connection",
-                        "connectorType": {
-                            "class": "ConnectorType",
-                            "qualifiedName": "Egeria:OpenMetadataTopicConnector:Kafka",
-                            "displayName": "Apache Kafka Open Metadata Topic Connector",
-                            "description": "Apache Kafka Open Metadata Topic Connector supports string based events over an Apache Kafka event bus.",
-                            "supportedAssetTypeName": "KafkaTopic",
-                            "expectedDataFormat": "PLAINTEXT",
-                            "connectorProviderClassName": "org.odpi.openmetadata.adapters.eventbus.topic.kafka.KafkaOpenMetadataTopicProvider"
-                            "recognizedConfigurationProperties": [
-                                "producer",
-                                "consumer",
-                                "local.server.id",
-                                "sleepTime"
-                            ]
-                        },
-                        "endpoint": {
-                            "class": "Endpoint",
-                            "headerVersion": 0,
-                            "address": "OMRSTopic.server.omas.omas.assetlineage.outTopic"
-                        },
-                        "configurationProperties": {
-                            "producer": {
-                                "bootstrap.servers": "server:port",
-                                "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
-                                "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
-                                "group.id": "custom-producer-id",
-                                "kafka.omrs.topic.id": "OMRSTopic"
+            "inTopicConnection": {
+                "class": "VirtualConnection",
+                "qualifiedName": "OutTopicConnector.Asset Lineage OMAS",
+                "displayName": "OutTopicConnector.Asset Lineage OMAS",
+                "description": "Client-side topic connection.",
+                "connectorType": {
+                    "class": "ConnectorType",
+                    "qualifiedName": "Asset Lineage Out Topic Client Connector",
+                    "displayName": "Asset Lineage Out Topic Client Connector",
+                    "description": "Connector supports the receipt of events on the Asset Lineage OMAS Out Topic.",
+                    "connectorProviderClassName": "org.odpi.openmetadata.accessservices.assetlineage.outtopic.connector.AssetLineageOutTopicClientProvider"
+                },
+                "embeddedConnections": [
+                    {
+                        "class": "EmbeddedConnection",
+                        "displayName": "Topic Event Bus",
+                        "embeddedConnection": {
+                            "class": "Connection",
+                            "connectorType": {
+                                "class": "ConnectorType",
+                                "qualifiedName": "Egeria:OpenMetadataTopicConnector:Kafka",
+                                "displayName": "Apache Kafka Open Metadata Topic Connector",
+                                "description": "Apache Kafka Open Metadata Topic Connector supports string based events over an Apache Kafka event bus.",
+                                "supportedAssetTypeName": "KafkaTopic",
+                                "expectedDataFormat": "PLAINTEXT",
+                                "connectorProviderClassName": "org.odpi.openmetadata.adapters.eventbus.topic.kafka.KafkaOpenMetadataTopicProvider"
+                                "recognizedConfigurationProperties": [
+                                    "producer",
+                                    "consumer",
+                                    "local.server.id",
+                                    "sleepTime"
+                                ]
                             },
-                            "consumer": {
-                                "bootstrap.servers": "server:port",
-                                "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
-                                "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
-                                "group.id": "custom-consumer-id",
-                                "kafka.omrs.topic.id": "OMRSTopic"
+                            "endpoint": {
+                                "class": "Endpoint",
+                                "headerVersion": 0,
+                                "address": "OMRSTopic.server.omas.omas.assetlineage.outTopic"
+                            },
+                            "configurationProperties": {
+                                "producer": {
+                                    "bootstrap.servers": "server:port",
+                                    "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+                                    "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+                                    "group.id": "custom-producer-id",
+                                    "kafka.omrs.topic.id": "OMRSTopic"
+                                },
+                                "consumer": {
+                                    "bootstrap.servers": "server:port",
+                                    "key.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+                                    "value.deserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+                                    "group.id": "custom-consumer-id",
+                                    "kafka.omrs.topic.id": "OMRSTopic"
+                                }
                             }
                         }
                     }
+                ]
+            },
+            "backgroundJobs": [
+                {
+                    "jobName": "LineageGraphJob",
+                    "jobInterval": 120,
+                    "jobEnabled": "false"
+                },
+                {
+                    "jobName": "AssetLineageUpdateJob",
+                    "jobInterval": 120,
+                    "jobEnabled": "false",
+                    "jobDefaultValue": "2021-01-01T00:00:00"
                 }
             ]
-        },
-        "backgroundJobs": [
-            {
-                "jobName": "LineageGraphJob",
-                "jobInterval": 120,
-                "jobEnabled": "false"
-            },
-            {
-                "jobName": "AssetLineageUpdateJob",
-                "jobInterval": 120,
-                "jobEnabled": "false",
-                "jobDefaultValue": "2021-01-01T00:00:00"
-            }
-        ]
-    }
-    ```
-
-#### Configuration reference
-
-| Property | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Is mandatory |
-|---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
-`lineageGraphConnection` | OCF configuration object that defines the Graph store connector type used. See [open-lineage-janus-connector](/connectors/governance-daemon/open-lineage-janus-connector) for more details.                                                                                                                                                                                                                                                                                                            | Yes |
-`accessServiceConfig.serverName` | the name of the metadata server where paired Asset Lineage OMAS is running.                                                                                                                                                                                                                                                                                                                                                                                                                            | Yes |
-`accessServiceConfig.serverPlatformUrlRoot` | The URL of the OMAG server platform running the metadata server where paired Asset Lineage OMAS is running. Also see [start-up information](#start-up-information) section.                                                                                                                                                                                                                                                                                                                            | Yes |
-`accessServiceConfig.user` | The username to access the server running Asset Lineage OMAS.                                                                                                                                                                                                                                                                                                                                                                                                                                          | Yes |
-`accessServiceConfig.password` | The user password to access the server running Asset Lineage OMAS. Can be left out for non-secured access.                                                                                                                                                                                                                                                                                                                                                                                             | No |
-`inTopicConnection` | [Connection object](/concepts/connection) that provides the Asset Lineage OMAS topic connection definition . If provided, it will override the default configuration.                                                                                                                                                                                                                                                                                                                                  | No |
-`backgroundJobs[n].jobName` | Key used to match the job name pre-defined in the open lineage server. Supported values `LineageGraphJob` and `AssetLineageUpdateJob`                                                                                                                                                                                                                                                                                                                                                                  | No |
-`backgroundJobs[n].jobInterval` | Interval (**seconds**) to execute the repetitive task defined by the named job above                                                                                                                                                                                                                                                                                                                                                                                                                   | No |
-`backgroundJobs[n].jobEnabled` | Controls if the job will be running (enabled) or not (disabled). Omitting the item in the `backgroundJobs` list had the same effect as setting the job to disable.                                                                                                                                                                                                                                                                                                                                     | No |
-`backgroundJobs[n].jobDefaultValue` | Setting initial value for the task, only used in case of `AssetLineageUpdateJob`. When configured and not present in the store this value becomes the starting point in time to poll for updates. After successful update initial value is no longer used and last known value form the store. The value should be always specified in standard internet data-time format `YYYY-MM-DDThh:mm:ss`. See [ISO-8601](https://datatracker.ietf.org/doc/html/rfc3339#section-5.8) for more info and examples. | No |
+        }
+        ```
+    
+    #### Configuration reference
+    
+    | Property | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Is mandatory |
+    |---|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---|
+    `lineageGraphConnection` | OCF configuration object that defines the Graph store connector type used. See [open-lineage-janus-connector](/connectors/governance-daemon/open-lineage-janus-connector) for more details.                                                                                                                                                                                                                                                                                                            | Yes |
+    `accessServiceConfig.serverName` | the name of the metadata server where paired Asset Lineage OMAS is running.                                                                                                                                                                                                                                                                                                                                                                                                                            | Yes |
+    `accessServiceConfig.serverPlatformUrlRoot` | The URL of the OMAG server platform running the metadata server where paired Asset Lineage OMAS is running. Also see [start-up information](#start-up-information) section.                                                                                                                                                                                                                                                                                                                            | Yes |
+    `accessServiceConfig.user` | The username to access the server running Asset Lineage OMAS.                                                                                                                                                                                                                                                                                                                                                                                                                                          | Yes |
+    `accessServiceConfig.password` | The user password to access the server running Asset Lineage OMAS. Can be left out for non-secured access.                                                                                                                                                                                                                                                                                                                                                                                             | No |
+    `inTopicConnection` | [Connection object](/concepts/connection) that provides the Asset Lineage OMAS topic connection definition . If provided, it will override the default configuration.                                                                                                                                                                                                                                                                                                                                  | No |
+    `backgroundJobs[n].jobName` | Key used to match the job name pre-defined in the open lineage server. Supported values `LineageGraphJob` and `AssetLineageUpdateJob`                                                                                                                                                                                                                                                                                                                                                                  | No |
+    `backgroundJobs[n].jobInterval` | Interval (**seconds**) to execute the repetitive task defined by the named job above                                                                                                                                                                                                                                                                                                                                                                                                                   | No |
+    `backgroundJobs[n].jobEnabled` | Controls if the job will be running (enabled) or not (disabled). Omitting the item in the `backgroundJobs` list had the same effect as setting the job to disable.                                                                                                                                                                                                                                                                                                                                     | No |
+    `backgroundJobs[n].jobDefaultValue` | Setting initial value for the task, only used in case of `AssetLineageUpdateJob`. When configured and not present in the store this value becomes the starting point in time to poll for updates. After successful update initial value is no longer used and last known value form the store. The value should be always specified in standard internet data-time format `YYYY-MM-DDThh:mm:ss`. See [ISO-8601](https://datatracker.ietf.org/doc/html/rfc3339#section-5.8) for more info and examples. | No |
+     
+    
+    #### Removing the Open Lineage Services from the server configuration
+    
+    !!! delete "DELETE - Remove Open Lineage Services from the server"
+        ```
+        {{serverURLRoot}}/open-metadata/admin-services/users/{{userId]}}/servers/{{serverName}}/open-lineage/configuration
+        ```
+ ### Start up information
  
-
-#### Removing the Open Lineage Services from the server configuration
-
-!!! delete "DELETE - Remove Open Lineage Configuration from the server"
-    ```
-    {{serverURLRoot}}/open-metadata/admin-services/users/{{userId]}}/servers/{{serverName}}/open-lineage/configuration
-    ```
-### Start up information
-
-!!! info "Runtime consideration"
-    It is important to consider that, to operate, open lineage server depends on the availability of metadata access server and asset lineage being up and running. This is the case because open lineage server discovers the event bus connectivity and the topic address from asset lineage during start-up. Consequently, it will always wait and retry until this condition is met, and it starts up successfully.
-
+ !!! info "Runtime consideration"
+     It is important to consider that, to operate, open lineage server depends on the availability of its Metadata Access Server (with Asset Lineage OMAS) being up and running. This is the case because Open Lineage Server discovers the event bus connectivity and the topic address from asset lineage during start-up. Consequently, it will always wait and retry until this condition is met, and it starts up successfully.
+    
 --8<-- "snippets/abbr.md"

--- a/site/docs/guides/admin/servers/configuring-the-audit-log.md
+++ b/site/docs/guides/admin/servers/configuring-the-audit-log.md
@@ -5,16 +5,9 @@
 
 Egeria's [audit log](/concepts/audit-log) provides a configurable set of destinations for audit records and other diagnostic logging for an [OMAG Server](/concepts/omag-server). Some destinations also support a query interface to allow an administrator to understand how the server is running.
 
-If the server is a development or test server, then the default audit log configuration is probably sufficient: the console audit log destination.
+Each audit log record has a severity that can be used to route it to one or more specific destinations.  Therefore, when an audit log destination is configured, it is optionally supplied with a list of severities to filter audit log records it should receive.
 
-!!! post "POST - set default audit log destination"
-    ```
-    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/default
-    ```
-
-    Using this option overrides all previous audit log destinations.
-
-If this server is a production server then you will probably want to set up the audit log destinations explicitly. You can add multiple destinations and each one can be set up to process specific severities of log records. The audit log severities are as follows:
+The audit log severities are as follows:
 
 | Severity | Description |
 |---|---|
@@ -34,77 +27,118 @@ If this server is a production server then you will probably want to set up the 
 | `PerfMon` | This log record contains performance monitoring timing information for specific types of processing. It is not normally logged to any destination, but can be added when needed. |
 | `<Unknown>` | Uninitialized Severity |
 
-!!! tip "The body of the request should be a list of severities"
-    If an empty list is passed as the request body then all severities are supported by the destination.
+The default audit log destination is the console audit log destination.  This writes selected parts of each audit log record to "standard out" (stdout). It is configured to receive log records of all severities except `Trace` and `PerfMon`.  
+
+The default audit log destination is added automatically to [Cohort Member](/concepts/cohort-member) servers when a repository, or cohort connection is configured.  
+
+For [View Servers](/concepts/view-server) and [Governance Servers](/concepts/governance-server), it is only added when other audit log destinations are configured.  Therefore, is it necessary to issue at least one of the following configuration commands for the audit log for these types of servers.
 
 ### Add audit log destinations
+
+If the server is a development or test server, then the default audit log configuration is probably sufficient, and you should use the following command:
+
+!!! post "POST - set default audit log destination"
+    ```
+    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/default
+    ```
+
+*Note:* Using this command overrides all previous audit log destinations configured for the server.
+
+If this server is a production server then you will probably want to set up the audit log destinations explicitly. You can add multiple destinations and each one can be set up to receive different severities of audit log records. 
 
 There are various destinations that can be configured for the audit log:
 
 === "console"
 
+    Since the default audit log destination is also a console audit log destination, only use this option to add the `Trace` and `PerfMon` severities.
+
     !!! post "POST - add console audit log destination"
-        This writes selected parts of each audit log record to stdout.
 
         ```
         {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/console
         ```
-
-=== "slf4j"
-
-    !!! post "POST - add slf4j audit log destination"
-        This writes full log records to the slf4j ecosystem.
-
-        ```
-        {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/slf4j
-        ```
-
-        When configuring slf4j as destination you also need to specify audit log logger category via the application properties. This is described in [Connecting the OMAG Audit Log Framework](/guides/admin/omag-server-platform-logging/#connecting-the-omag-audit-log-framework) section of the developer logging guide.
+        !!! tip "The body of the request should be a list of severities"
+            If an empty list is passed as the request body then all severities are supported by the destination.
 
 === "file"
+    This destination writes JSON files in a shared directory.  One file for each audit log record.
 
     !!! post "POST - add JSON file-based audit log destination"
-        This writes JSON files in a shared directory.
-
         ```
         {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/files
         ```
+        !!! tip "The body of the request should be a list of severities"
+            If an empty list is passed as the request body then all severities are supported by the destination.
 
 === "event"
+    This destination writes each log record as an event on the supplied event topic. It assumes that the [event bus](#set-up-the-default-event-bus) is set up first.
 
     !!! post "POST - add event-based audit log destination"
-        This writes each log record as an event on the supplied event topic. It assumes that the [event bus](#set-up-the-default-event-bus) is set up first.
-
         ```
         {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/event-topic
         ```
+        !!! tip "The body of the request should be a list of severities"
+            If an empty list is passed as the request body then all severities are supported by the destination.
+
+=== "slf4j"
+    This writes full log records to the slf4j ecosystem.   When configuring slf4j as destination you also need to specify audit log logger category via the application properties of the [OMAG Server Platform](/concepts/omag-server-platform). This is described in [Connecting the OMAG Audit Log Framework](/guides/admin/omag-server-platform-logging/#connecting-the-omag-audit-log-framework) section of the developer logging guide.
+
+    The configuration of the slf4j ecosystem determines it ultimate destination(s).
+
+    !!! post "POST - add slf4j audit log destination"
+        ```
+        {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/slf4j
+        ```
+        !!! tip "The body of the request should be a list of severities"
+            If an empty list is passed as the request body then all severities are supported by the destination.
 
 === "connection"
+    This sets up an audit log destination that is described though a [connection](/concepts/connection). In this case, the connection is passed in the request body and the supported severities are supplied in the connection's configuration properties.
 
     !!! post "POST - add connection-based audit log destination"
-        This sets up an audit log destination that is described though a [connection](/concepts/connection). In this case, the connection is passed in the request body and the supported severities can be supplied in the connection's configuration properties.
-
         ```
         {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/connection
         ```
 
 === "list"
+    It is also possible to set up all the audit log destinations in one command as a list of connections. Using this option overrides all previous audit log destinations and so can be used as the update command.  The list of connections is passed in the request body and the supported severities are supplied in each connection's configuration properties.
 
     !!! post "POST - add a list of connection-based audit log destinations"
-        It is also possible to set up the audit log destinations as a list of connections.
-        Using this option overrides all previous audit log destinations.
-
         ```
         {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations
         ```
 
-### Remove audit logs
+### Retrieving audit log destinations
 
-The following will remove all audit log destinations:
+The configured list of audit log destinations can be retrieved using this command:
 
-!!! post "POST - clear all audit log destinations"
-    Clears the list of audit log destinations from the configuration enabling you to add a new set of audit log destinations.
-
+!!! get "GET - the list of configured audit log destinations"
     ```
-    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/none
+    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations
+    ```
+
+### Updating audit log destinations
+
+Audit log destinations can be updated individually, by qualified name using the following command:
+
+    !!! post "POST - update connection-based audit log destination"
+        ```
+        {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/connection/{{qualifiedName}}
+        ```
+If you are not sure what the audit log connection is called, [retrieve the list of configured audit log connections](#retrieving-audit-log-destinations) and the resulting list of audit log connections will include the qualified names.
+
+### Remove audit log destinations
+
+The following will remove all audit log destinations, enabling you to add a new set of audit log destinations.
+
+!!! delete "DELETE - clear all audit log destinations"
+    ```
+    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations
+    ```
+
+It is also possible to remove a single audit log destination using its connection's qualified name.
+
+!!! delete "DELETE - clear then named audit log destination"
+    ```
+    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/audit-log-destinations/{{qualifiedName}}
     ```

--- a/site/docs/guides/admin/servers/configuring-the-repository-proxy-connector.md
+++ b/site/docs/guides/admin/servers/configuring-the-repository-proxy-connector.md
@@ -10,49 +10,51 @@ The mapping between a third party metadata repository and the open metadata prot
 
 They are configured as follows.
 
-### Configure the repository connector
+??? info "Configuring the repository connector"
+    ### Configure the repository connector
 
-The repository proxy can act as a proxy to a third party metadata repository. This is done by adding the connection for the [repository connector](/concepts/repository-connector) as follows.
+    Add the connection for the [repository connector](/concepts/repository-connector) as follows.
+    
+    !!! post "POST - configure the repository connector"
+        ```
+        {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/local-repository/mode/repository-proxy/connection
+        ```
+    
+        The request body should be the connection to use for configuring the connector, which can include any connector-specific options as well as general details like the endpoint and credentials for the third party repository. The `connectorProvider` should be set to the fully-qualified Java class name for the [connector provider](/concepts/connector-provider) of the repository connector.
+    
+    ??? example "Example: connection to configure the IBM Information Governance Catalog repository connector"
+        ```json linenums="1" hl_lines="5 9 12 13"
+        {
+          "class": "Connection",
+          "connectorType": {
+            "class": "ConnectorType",
+            "connectorProviderClassName": "org.odpi.egeria.connectors.ibm.igc.repositoryconnector.IGCOMRSRepositoryConnectorProvider"
+          },
+          "endpoint": {
+            "class": "Endpoint",
+            "address": "infosvr:9446",
+            "protocol":"https"
+          },
+          "userId": "a-user",
+          "clearPassword": "a-password",
+          "configurationProperties": {
+            "defaultZones": ["default"]
+          }
+        }
+        ```
+    
+        In this example, the type of connector to configure is given by the class name on line 5, and details about how to connect to the third party repository (IBM Information Governance Catalog) itself are provided on lines 9 (hostname and port), and 12-13 (credentials).
 
-!!! post "POST - configure the repository connector"
-    ```
-    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/local-repository/mode/repository-proxy/connection
-    ```
+??? info "Configuring the event mapper connector"
+    ### Configure the event mapper connector
 
-    The request body should be the connection option to use for configuring the connector, which can include any connector-specific options as well as general details like the endpoint and credentials for the third party repository.
+    Any open metadata repository that supports its own API **must** also implement an event mapper to ensure the [Open Metadata Repository Services (OMRS)](/services/omrs) is notified when metadata is added to the repository without going through the open metadata APIs.
 
-??? example "Example: connection to configure the IBM Information Governance Catalog repository connector"
-    ```json linenums="1" hl_lines="5 9 12 13"
-    {
-      "class": "Connection",
-      "connectorType": {
-        "class": "ConnectorType",
-        "connectorProviderClassName": "org.odpi.egeria.connectors.ibm.igc.repositoryconnector.IGCOMRSRepositoryConnectorProvider"
-      },
-      "endpoint": {
-        "class": "Endpoint",
-        "address": "infosvr:9446",
-        "protocol":"https"
-      },
-      "userId": "a-user",
-      "clearPassword": "a-password",
-      "configurationProperties": {
-        "defaultZones": ["default"]
-      }
-    }
-    ```
+    The [event mapper is a connector](/concepts/event-mapper-connector) that listens for proprietary events from the repository and converts them into calls to the OMRS. The OMRS then distributes this new metadata.
 
-    In this example, the type of connector to configure is given by the class name on line 5, and details about how to connect to the third party repository (IBM Information Governance Catalog) itself are provided on lines 9 (hostname and port), and 12-13 (credentials).
+    !!! post "POST - configure event mapper"
+        ```
+        {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/local-repository/event-mapper-details?connectorProvider={{fullyQualifiedJavaClassName}}&eventSource={{resourceName}}
+        ```
 
-### Configure the event mapper connector
-
-Any open metadata repository that supports its own API **must** also implement an event mapper to ensure the [Open Metadata Repository Services (OMRS)](/services/omrs) is notified when metadata is added to the repository without going through the open metadata APIs.
-
-The [event mapper is a connector](/concepts/event-mapper-connector) that listens for proprietary events from the repository and converts them into calls to the OMRS. The OMRS then distributes this new metadata.
-
-!!! post "POST - configure event mapper"
-    ```
-    {{platformURLRoot}}/open-metadata/admin-services/users/{{adminUserId}}/servers/{{serverName}}/local-repository/event-mapper-details?connectorProvider={{fullyQualifiedJavaClassName}}&eventSource={{resourceName}}
-    ```
-
-    The `connectorProvider` should be set to the fully-qualified Java class name for the [connector provider](/concepts/connector-provider), and the `eventSource` should give the details for how to access the events (for example, the hostname and port number of an Apache Kafka bootstrap server).
+        The `connectorProvider` should be set to the fully-qualified Java class name for the [connector provider](/concepts/connector-provider) of the event mapper, and the `eventSource` should give the details for how to access the events (for example, the hostname and port number of an Apache Kafka bootstrap server).


### PR DESCRIPTION
This adds folded sections to the configuration page for each server type.  It also adds missing commands (such as update) for managing audit log destinations to the audit log configuration sections