### PR TITLE
#774 Add frame-src CSP for google calendar & youtube

### DIFF
--- a/site/overrides/main.html
+++ b/site/overrides/main.html
@@ -20,6 +20,6 @@
   child-src 'self' https://calendar.google.com/ https://www.youtube.com/;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://giscus.app/;
   script-src 'self' 'unsafe-inline'  https://giscus.app/;
-  frame-src 'self' https://giscus.app/;"
+  frame-src 'self' https://calendar.google.com/ https://www.youtube.com/ https://giscus.app/;"
   />
 {% endblock %}


### PR DESCRIPTION
Adds frame-src CSP for google calendar & youtube which were reporting CSP errors.
Fixes #774 
Tested locally