### PR TITLE
Add evolving to the future solutions

### DIFF
--- a/site/docs/egeria-solutions/building-data-specifications/overview.md
+++ b/site/docs/egeria-solutions/building-data-specifications/overview.md
@@ -1,14 +1,84 @@
----
-hide:
-- toc
----
-
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Egeria project. -->
 
 # Building data specifications
 
---8<-- "snippets/work-in-progress.md"
+Every data project begins with the same conversation, and it is rarely a smooth one.  The people who need the data describe it in business language.  The people who have to supply it need column names, types and units.  In between, requirements are written into documents and spreadsheets that no tool can act on, and that quietly go stale the moment the project starts building.
 
+A *data specification* replaces that document with metadata.  It records what data a project or new capability needs, in a form that can be reviewed by the business, matched against the data you actually hold, and used to generate what is missing.
+
+## What a data specification contains
+
+A [data specification](/concepts/data-specification) is a [collection](/concepts/collection) whose members are [data structures](/concepts/data-structure).  Each data structure is an ordered list of [data fields](/concepts/data-field), and each data field describes one type of data item that is required.
+
+The ordering matters: it identifies the order in which the fields should be implemented in the resulting data source.  A field can also be marked as optional, or as something that may occur several times.
+
+Data fields carry the detail that makes a requirement testable rather than aspirational:
+
+| Property | Purpose |
+|----------|---------|
+| `dataType`, `length`, `minimumLength`, `precision` | The logical type and size of the value. |
+| `units`, `absoluteUncertainty`, `relativeUncertainty` | What the value is measured in, and the accuracy of the instrument that produced it - essential for scientific and manufacturing data. |
+| `isNullable`, `defaultValue` | Whether the value may be absent, and what to use when it is. |
+| `orderedValues`, `sortOrder` | Whether the values are sorted, and in which direction. |
+| `aliases`, `namePatterns` | Alternative names and match patterns, used when comparing the specification against a real schema. |
+| `namespacePath` | Optional namespace used to build a qualified name for the field. |
+| `isDeprecated` | Marks a field that should no longer be used. |
+
+The *ObjectIdentifier* classification marks a field that is used as a unique identifier, which is what lets tooling recognize the key of a data set without being told.
+
+The example below is the data structure behind one of Egeria's own digital products.  It shows the data specification it belongs to, and the ordered data fields that make it up.
+
+--8<-- "snippets/data-structures/data-structure-for-digital-product-list-mermaid-graph.md"
+
+## Reusing definitions through a data dictionary
+
+Specifying every project's data from scratch produces subtly different definitions of the same thing, which is how an organization ends up with five incompatible versions of *customer name*.
+
+A [data dictionary](/concepts/data-dictionary) is an organized, curated collection of pre-defined data fields that acts as the reference set for data professionals.  A new specification is assembled by selecting from it, and only genuinely new requirements are defined from first principles.  A dictionary might describe the fields found in a particular data store, or the typical fields of a [subject area](/concepts/subject-area), or serve as a set of templates for building new specifications.
+
+The graph below shows a single data field - *Display Name* - held in a data dictionary and reused by many data structures.  That reuse is the whole point: consumers of any of those structures know they are looking at the same thing.
+
+--8<-- "snippets/data-fields/display-name-mermaid-graph.md"
+
+## Adding meaning
+
+A data field on its own says what shape the data is.  Two further links say what it *means*:
+
+* A [glossary term](/practices/common-data-definitions/anatomy-of-a-glossary) attached to the field states the business concept it holds, using the definitions your subject-matter experts have agreed.
+* A [data class](/concepts/data-class) attached to the field states the kind of value it is - a postcode, an email address, a patient identifier - which is what allows values to be recognized and validated automatically.
+
+This is the join between the work described in [Capturing expertise](/egeria-solutions/capturing-knowledge/overview) and the concrete data that a project delivers.
+
+## From specification to implementation
+
+As a project progresses, the specification stops being a wish list and starts being a template and a test:
+
+* The `aliases` and `namePatterns` on each field are used to **match** the specification against the [schemas](/concepts/schema) of data assets you already hold, to find out what part of the requirement is already met.
+* The data structures can be used to **manufacture** schemas for the data assets that have to be built, so that the implementation starts from the agreed definitions rather than a fresh interpretation of them.
+* The *DataStructureDefinition* relationship links a data structure to a certification type, so that a data source can be **certified** as conforming to the structure and its associated glossary terms and data classes.
+
+Because the same data fields are referenced throughout, the trail from a project requirement to the column that satisfies it stays intact, and a change to the definition is visible everywhere it is used.
+
+## Where else data specifications are used
+
+The same artefact appears at both ends of a data exchange, which is what allows the two ends to be matched:
+
+* A **data sharing request** in a [data sharing hub](/patterns/harvest-and-publish/overview) uses a data specification to state what the requester needs.  The hub's data dictionary is the menu the requester selects from.
+* A **[digital product](/concepts/digital-product)** uses one, through the *DataDescription* relationship, to describe the data it delivers to its subscribers.
+
+Requirement, request and offer are then expressed in one vocabulary, so a consumer can be pointed at the product that already satisfies what they were about to ask for.
+
+## Tools
+
+* The [Data Designer](/services/omvs/data-designer/overview) API creates and maintains data specifications, data dictionaries, data structures and data fields.
+* [Dr.Egeria](/user-interfaces/dr-egeria/overview) allows a specification to be authored as a Markdown document, so it can be drafted and reviewed by the business before it is loaded.
+* [Egeria Explorer](/user-interfaces/egeria-explorer/overview) displays the specification and its mermaid graphs, and navigates from a field to everywhere it is used.
+
+!!! info "Related information"
+
+    * [Model 0580 Data Dictionaries](/types/5/0580-Data-Dictionaries) - the open metadata types for data specifications, data dictionaries, data structures and data fields.
+    * [Data specification](/concepts/data-specification), [data dictionary](/concepts/data-dictionary), [data structure](/concepts/data-structure) and [data field](/concepts/data-field) concepts.
+    * [Harvest and Publish](/patterns/harvest-and-publish/overview) - data sharing hubs and digital products, both of which build on data specifications.
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/egeria-solutions/capturing-knowledge/overview.md
+++ b/site/docs/egeria-solutions/capturing-knowledge/overview.md
@@ -1,13 +1,74 @@
----
-hide:
-- toc
----
-
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Egeria project. -->
 
 # Capturing knowledge from your subject-matter experts
 
---8<-- "snippets/work-in-progress.md"
+Most of what an organization knows about its data is not written down.  It is held by the people who have worked with it for years: which system is authoritative, why that column is always null before 2019, what the difference is between a *customer* and an *account holder*, and which steps have to happen before a data set can be released.  That knowledge walks out of the door when they change jobs, and it is re-learned - expensively - by whoever comes next.
+
+The obstacle is never the will to write it down.  It is that capturing knowledge is usually organized as a documentation project running alongside the real work, in a tool the experts do not otherwise use, producing an artefact that no system can act on.  Egeria's approach is to make the capture part of the work, and to make what is captured immediately useful.
+
+## What is worth capturing
+
+### Meaning
+
+A [glossary](/practices/common-data-definitions/anatomy-of-a-glossary) is a collection of semantic definitions, focused on the meaning of data.  Each [glossary term](/concepts/glossary-term) describes a single concept, starting with a name and a short description that distinguishes it from every other term.  Where a term matters enough, it can be built out with a detailed description, usage notes, examples, images and links to further information.
+
+Terms are organized with categories, related to each other with [term relationships](/types/3/0350-Related-Terms) that pin down *how* two concepts are connected, and classified to show how they are intended to be used.  An organization typically has several glossaries, each with a defined scope and an owner responsible for the quality of what it contains.
+
+### Scope
+
+[Subject areas](/concepts/subject-area) group the definitions into the topics of knowledge that matter to the organization - typically the data that is widely shared, where consistency between copies has business value.  Deciding the subject areas is a strategic act rather than a modelling exercise: it determines where the effort goes.
+
+### Values
+
+Meaning is only half the story.  The [valid values](/guides/planning/valid-values/overview) and [reference data](/features/reference-data-management/overview) that define which values are permitted, and the quality rules that check them, turn a definition into something that can be enforced.  A [data class](/concepts/data-class) captures the shape of a particular kind of value, so that data of that kind can be recognized automatically wherever it appears.
+
+### Procedures
+
+Expertise is not only vocabulary; much of it is procedure - the sequence of steps an experienced person follows to onboard a supplier, release a data set or retire a system.  A [governance action process](/concepts/governance-action-process) captures that sequence as metadata: the steps, the order, and the conditions under which each one runs.  Written this way, the procedure is documentation *and* an executable process, so what the expert described is what actually runs - and the description carries the explanation of what each step is for:
+
+--8<-- "snippets/governance-action-processes/onboard-landing-area-files-for-clinical-trial-project-mermaid-graph.md"
+
+### Context for people and AI
+
+Newer types capture the knowledge that helps someone - or something - work effectively in a domain: [perspectives](/types/1/0145-Perspectives) describe a point of view on the metadata, [questions](/types/3/0340-Dictionary) record the things people actually need answered, and skills and skill sets describe the capabilities a role requires.  This material is what gives an AI application useful context about your organization, rather than generic knowledge about the world.
+
+## Making capture part of the work
+
+[Dr.Egeria](/user-interfaces/dr-egeria/overview) is the route in for people who will never use a metadata tool.  Definitions are authored as ordinary Markdown documents that mix explanation with the commands that create the metadata - the approach described under [literate governance](/concepts/literate-governance).
+
+This matters practically:
+
+* The expert works in whatever editor they already use - including [Obsidian](/user-interfaces/dr-egeria/overview) or a notebook environment - not in a system they have to be trained on.
+* The document can be circulated for peer review, argued over and corrected, because it reads as prose.
+* It can be validated and reprocessed as many times as it takes, and the command language includes report requests so the author can check that what they meant is what got loaded.
+* The artefact people collaborate on and the artefact that configures the ecosystem are the same artefact, so they cannot drift apart.
+
+A particularly effective pattern is the **form and report round trip**: Egeria generates a Markdown form containing everything that is known so far - for example, every field in a newly derived data dictionary - the expert and their colleagues fill in the gaps, and the completed document is loaded back.  This is how [Robbie Records](/practices/coco-pharmaceuticals/scenarios/patient-data-sharing-hub/overview) documents his patient data dictionary, and the document itself sparks enough interest that colleagues ask for copies.
+
+Not all contributions need to be that formal.  The [Feedback Manager](/services/omvs/feedback-manager/overview) API supports comments, informal tags, reviews and ratings, which is how knowledge gets crowd-sourced from the people using a resource day to day - see [user feedback](/features/user-feedback/overview).  Note logs let an owner post the status and events that consumers need to know about.
+
+## Putting the knowledge to work
+
+Captured definitions earn their keep by being attached to things:
+
+* Glossary terms and data classes attach to [data fields](/concepts/data-field) in a [data specification](/egeria-solutions/building-data-specifications/overview), so a project's requirements are stated in agreed language.
+* They attach to the schema attributes of catalogued assets, so a consumer reading a column definition sees what the data means, not just its type.
+* [Governed data classifications](/types/4/0422-Governed-Data-Classifications) link definitions to governance requirements, so classifying data also determines how it must be handled.
+
+The [common data definitions](/practices/common-data-definitions/overview) practice describes the full lifecycle around this - harvesting existing definitions, managing them with subject-matter experts, consuming them in the tools that build new capability, and delivering value in production - and [semantic to implementation](/practices/common-data-definitions/semantic-to-implementation) shows how the semantic layer connects to the physical one.
+
+## Seeing it in practice
+
+* [Defining the subject areas for data](/practices/coco-pharmaceuticals/scenarios/defining-subject-areas/overview) - Erin Overview and Peter Profile start from Coco Pharmaceuticals' existing enterprise information model and discover that it mirrors the org chart and challenges nothing.  Talking to manufacturing and sales about where the business is going produces a very different set of subject areas, centred on patient, clinician and treatment.
+* [Defining a glossary](/practices/coco-pharmaceuticals/scenarios/defining-a-glossary/overview) - building the semantic definitions that give those subject areas their meaning.
+* [Planning for common data definitions](/practices/coco-pharmaceuticals/scenarios/planning-for-common-data-definitions/overview) - how the work is organized and who does it.
+
+!!! info "Related information"
+
+    * [Anatomy of a glossary](/practices/common-data-definitions/anatomy-of-a-glossary) - glossaries, terms, categories, relationships and classifications.
+    * [Glossary Manager](/services/omvs/glossary-manager/overview) and [Subject Area](/services/omvs/subject-area/overview) APIs - maintaining glossaries, terms and subject area definitions.
+    * [Literate governance](/concepts/literate-governance) - the philosophy behind Dr.Egeria's Markdown documents.
+    * [Organization Engagement](/patterns/organization-engagement/overview) - the wider pattern of engaging people across the organization.
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/egeria-solutions/crossing-data-boundaries/overview.md
+++ b/site/docs/egeria-solutions/crossing-data-boundaries/overview.md
@@ -1,13 +1,64 @@
----
-hide:
-- toc
----
-
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Egeria project. -->
 
 # Crossing Data Boundaries
 
---8<-- "snippets/work-in-progress.md"
+Organizations sort their data into categories, and then manage each category separately - its own tool, its own team, its own vocabulary, often its own budget.  The categories are useful; the boundaries between them are where value quietly leaks away, because any question that spans two of them turns into a project.
+
+| Category | What it is | Where it usually lives |
+|----------|------------|------------------------|
+| **Master data** | The key entities the business is described in terms of: customers, suppliers, products, people, organizations, locations, systems. | An MDM hub, or several systems of record that disagree. |
+| **Reference data** | The agreed code sets and valid values that other data refers to: country codes, product categories, status values. | Spreadsheets, and a table in each application. |
+| **Metadata** | What data exists, where it is implemented, how it is structured, where it came from and how it must be governed. | A catalog, if there is one. |
+| **Transactional data** | The operational record of what the business did. | The applications and data stores that run the business. |
+| **Analytics** | What has been derived from the rest: measurements, models, reports, insight. | Warehouses, lakes, notebooks and dashboards. |
+
+Egeria's contribution is not to move this data into one place.  It is to hold the *descriptions* of all of it in one knowledge graph, and to link them, so that the relationships that cross the boundaries can be followed.
+
+## What gets linked
+
+**Master data** is described by the same open metadata types as everything else.  [Assets](/concepts/asset) describe the systems and data stores; [actor profiles](/features/people-roles-organizations/overview) describe the people, teams and organizations; [digital products](/concepts/digital-product) describe what is offered; [locations](/types/0/0025-Locations) describe where things are, physically and digitally.  Because these are ordinary metadata elements, a person can be linked to the role that makes them responsible for an asset, and an asset can be linked to the location and the business capability it serves.
+
+**Reference data** is managed as [valid values and reference data sets](/features/reference-data-management/overview), so the code set exists once and every use of it points at the same definition.  A [data class](/concepts/data-class) describes the kind of value a field holds, which allows values encountered in real data to be recognized against the reference set rather than eyeballed.
+
+**Metadata** is the connective tissue: the schemas describing the structure of each store, the [lineage](/features/lineage-management/overview) describing how data moves between them, the [information supply chains](/concepts/information-supply-chain) describing those flows in business terms, and the governance definitions describing how each must be handled.
+
+**Analytics and insight** come back into the graph rather than accumulating outside it.  [Survey reports](/concepts/survey-report) hold the measurements and profiles produced by analysing resources, and their annotations attach to the assets they describe, so the analysis of a data set is found next to the data set.
+
+## The joins that make it work
+
+Linking categories requires something to join on.  Egeria provides several, and they are worth knowing because they are the mechanisms that make cross-boundary questions answerable:
+
+* **Glossary terms and data classes** are the semantic join.  When the same term is attached to a field in an operational store, a field in a warehouse table and a data field in a project's [data specification](/egeria-solutions/building-data-specifications/overview), those three things are known to mean the same thing - even though nothing about their names or types agrees.
+* **Data fields in a data dictionary** are the field-level join across stores.  This is what a [data sharing hub](/patterns/harvest-and-publish/overview) is built on: one data field identifies similar data wherever it appears, so a consumer describes what they want once rather than once per store.
+* **[External identifiers](/features/external-identifiers/overview)** are the identity join across tools.  The same resource is known by different names in different systems; recording those names against one asset means an automated process can look up whichever identifier the tool it is calling expects.
+* **Reference values** are the coding join.  Shared code sets let data from different sources be compared and combined without a translation step being invented each time.
+* **Lineage and information supply chains** are the flow join, connecting a transactional source to the analytics eventually derived from it, through every hop in between.
+
+## What this makes possible
+
+Once the links exist, questions that used to require an investigation become queries:
+
+* Which digital products depend on data originating in a particular country - and therefore which are affected by a change in that jurisdiction's rules?
+* Which analytics and reports are built on a data set that has just been reclassified as confidential?
+* Which teams and roles need to be told when a system is retired, because they own something downstream of it?
+* Where else does this data field appear, and do those copies agree with the authoritative source?
+
+The same links are what allow [automation](/patterns/active-governance/overview) to act.  A governance action can navigate from a classification to the resources it applies to, and from those resources to the people responsible, without any of that navigation being hard-coded.
+
+## Sharing across the boundary in both directions
+
+Linking descriptions is one half; moving data across the boundary is the other.  The [Harvest and Publish](/patterns/harvest-and-publish/overview) pattern packages open metadata - including the master data, reference data and insight described above - into [digital products](/concepts/digital-product) delivered as tabular data sets into whatever the consuming team already uses: a CSV file, a database table, a Kafka topic.  Reference data curated in Egeria can therefore be distributed to the applications that need it, and insight derived from the ecosystem can be delivered to the analysts who will act on it.
+
+The graph below is one such family from Egeria's own product catalog - the master data of the ecosystem, published as products that other tools can subscribe to:
+
+--8<-- "snippets/collections/digital-products/actor,-places-and-product-master-data-mermaid-graph.md"
+
+!!! info "Related information"
+
+    * [Reference data management](/features/reference-data-management/overview) - representing, distributing and governing reference data.
+    * [External identifiers](/features/external-identifiers/overview) - correlating the same resource across different tools.
+    * [Information Exchange](/patterns/information-exchange/overview) - the automation that keeps metadata synchronized between tools and platforms.
+    * [Harvest and Publish](/patterns/harvest-and-publish/overview) - data sharing hubs and the digital product catalog.
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/egeria-solutions/evolving-to-the-future/index.md
+++ b/site/docs/egeria-solutions/evolving-to-the-future/index.md
@@ -1,13 +1,66 @@
----
-hide:
-- toc
----
-
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Egeria project. -->
 
 # Evolving to the future
 
---8<-- "snippets/work-in-progress.md"
+[Leveraging your estate](/egeria-solutions/leveraging-your-estate) is about understanding the digital resources you already have and making better use of them.  Once that picture is emerging, attention turns to what comes next: the transformation projects that build the new capability your organization needs.
+
+The solutions under *Evolving to the future* accelerate that work.  What holds a transformation project up is rarely the technology.  It is not being able to say precisely what data is needed; expertise that lives in people's heads and is never written down; designs that drift away from what actually got built; boundaries between the different kinds of data an organization keeps; and the awkward handovers between automated processes and the people who have to make the decisions.  Egeria has something to offer in each case.
+
+## Building data specifications
+
+At the start of a project, the need is to articulate *what data is required* - before anyone knows which system it will come from, or whether it exists at all.
+
+A [data specification](/concepts/data-specification) captures exactly that.  It is built from [data structures](/concepts/data-structure), each an ordered list of [data fields](/concepts/data-field) describing the logical type of every data item needed, and each field can be linked to a [data class](/concepts/data-class) and a [glossary term](/practices/common-data-definitions/anatomy-of-a-glossary) so that its meaning is unambiguous.  A [data dictionary](/concepts/data-dictionary) holds pre-defined, reusable fields, so later projects specify their requirements by selecting from definitions the organization has already agreed rather than inventing new ones.  As the project progresses, the specification is matched against - and used to manufacture - the schemas of the concrete data assets that satisfy it.
+
+The same artefact does more than start projects.  A [data sharing request](/patterns/harvest-and-publish/overview) uses a data specification to say what data is being asked for, and a [digital product](/concepts/digital-product) uses one to describe what it delivers.  Requirement, request and offer are all expressed in the same vocabulary, which is what allows them to be matched to each other.
+
+* Solution page: [Building data specifications](/egeria-solutions/building-data-specifications/overview)
+* Open metadata types: [0580 Data Dictionaries](/types/5/0580-Data-Dictionaries) - maintained through the [Data Designer](/services/omvs/data-designer/overview) API.
+
+## Capturing expertise
+
+Most of what an organization knows about its data is not written down anywhere.  It is held by the people who have worked with it for years, and it is lost when they move on.
+
+Capturing that expertise means building [glossaries](/practices/common-data-definitions/anatomy-of-a-glossary) that define what terms actually mean, organizing them into [subject areas](/concepts/subject-area), describing repeatable procedures as [governance action processes](/concepts/governance-action-process), and adding the valid values, reference data and quality rules that go with them.  Together these form the *common data definitions* that let different systems and teams share data with a shared understanding - the full picture is described under [common data definitions](/practices/common-data-definitions/overview).
+
+The practical difficulty is never the type system; it is getting busy experts to contribute.  This is why [Dr.Egeria](/user-interfaces/dr-egeria/overview) matters here: definitions are authored as ordinary Markdown documents that can be drafted, circulated for review and corrected in whatever editor the author already uses, then loaded into open metadata.  The goal is for capture to become a natural part of doing the work, rather than a documentation project that competes with it.
+
+The Coco Pharmaceuticals scenarios show how this starts:
+
+* [Defining the subject areas for data](/practices/coco-pharmaceuticals/scenarios/defining-subject-areas/overview) - Erin Overview and Peter Profile discover that their existing enterprise information model simply mirrored the org chart, and that focusing on the business transformation produces a very different, and far more useful, set of subject areas.
+* [Defining a glossary](/practices/coco-pharmaceuticals/scenarios/defining-a-glossary/overview) - building the semantic definitions that give those subject areas their meaning.
+
+Solution page: [Capturing expertise](/egeria-solutions/capturing-knowledge/overview)
+
+## Blueprints to delivery
+
+A [solution blueprint](/concepts/solution-blueprint) captures the design of a solution or process: its key [components](/concepts/solution-component), the roles involved, and how data flows between them.  It deliberately stops short of the detail found in a UML or E-R model - its purpose is to support a conversation with stakeholders, so it models only what those people need to discuss and agree on.
+
+Its value grows as the project delivers.  Components are linked to the digital resources that implement them using the [ImplementedBy](/types/7/0737-Solution-Implementation) relationship as those resources appear, so the design and the implementation stay connected instead of drifting apart, and progress becomes visible against the design everyone agreed to.  Once the solution is running, the blueprint becomes the natural aggregation point for the operational picture - the metrics, statistics and [lineage](/concepts/information-supply-chain) that show whether the thing that was built is behaving as designed.
+
+Solution page: [Blueprints to delivery](/egeria-solutions/solution-blueprints/overview)
+
+## Crossing data boundaries
+
+Organizations divide their data into categories and then manage each in its own tool, with its own team and its own vocabulary: master data about the key entities of the business; reference data and code sets; metadata describing where everything is; the transactional data the business runs on; and the analytics derived from it.  Each boundary is a place where value leaks away, because a question that spans two categories cannot be answered without a project.
+
+Egeria's contribution is to link them.  The master data - [assets](/concepts/asset), people and organizations, [digital products](/concepts/digital-product), locations - sits in the same knowledge graph as the reference data that codes it, the metadata that describes where it is implemented and how it flows, and the insight derived from analysing it.  Once those links exist, a question such as which products depend on data from a given location, or which analytics are built on a data set that has just been reclassified, becomes a query rather than an investigation.
+
+Solution page: [Crossing data boundaries](/egeria-solutions/crossing-data-boundaries/overview)
+
+## Human in the loop
+
+Transformation projects run on a partnership between people and automation, and the handover in each direction has to work.
+
+In one direction, people need to see what is going on.  Egeria's [user interfaces](/user-interfaces) show both the structural picture - what exists, how it is defined, how it connects - and the operational status of the ecosystem, with [Egeria Operations](/user-interfaces/egeria-operations/overview) covering the servers, connectors, governance engines and engine actions, and [Egeria Audit](/user-interfaces/egeria-audit/overview) covering exceptions, certifications, licenses and users.
+
+In the other direction, automation needs to reach people.  Egeria's own [governance actions](/concepts/governance-action) - and any other automation connected to the ecosystem, including AI applications - can raise anything from an informational [notification](/concepts/notification) that simply asks to be read, through to a [to-do](/concepts/to-do): a work item assigned to a role, with a priority and a status, that the automation waits on before it continues.  Because an individual has no REST API to call, this is how a process that hits a decision only a person can make gets that decision and carries on.  Who is notified, about what, and how, is managed through the [Notification Manager](/services/omvs/notification-manager/overview) API.
+
+Solution page: [Human in the loop](/egeria-solutions/human-in-the-loop/overview)
+
+---
+
+As the new capability is delivered and begins to operate, the open metadata ecosystem that supported its development becomes a source of insight in its own right.  That is the subject of [Accelerating insight](/egeria-solutions/accelerating-insight).
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/egeria-solutions/human-in-the-loop/overview.md
+++ b/site/docs/egeria-solutions/human-in-the-loop/overview.md
@@ -1,15 +1,76 @@
----
-hide:
-- toc
----
-
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Egeria project. -->
 
 # Human in the loop
 
+Automation can catalogue, survey, classify, provision and monitor.  What it cannot do is make the judgement calls: whether these two records really are the same customer, whether this data set may be released, whether an unexpected survey result is a problem or a quirk.  Those need a person - and the person needs to find out that they are needed, understand the situation well enough to decide, and have their decision picked up by the process that was waiting.
 
---8<-- "snippets/work-in-progress.md"
+Getting that loop to work is the difference between automation that scales and automation that stalls.
 
+## People need to see what is happening
+
+The first half of the loop is visibility.  Egeria's [user interfaces](/user-interfaces) present both the structural picture and the operational one.
+
+**The structural picture** - what exists and how it fits together:
+
+* [The Catalog](/user-interfaces/the-catalog/overview) for the inventories of infrastructure, data assets, APIs and processes.
+* [Egeria Explorer](/user-interfaces/egeria-explorer/overview) for the wider knowledge graph, including the type system and the valid value sets behind it.
+* [Lineage Explorer](/user-interfaces/lineage-explorer/overview) for where data came from and where it goes.
+* [Mermaid graphs](/user-interfaces/mermaid/overview), generated from the metadata itself, so a diagram is never out of date with what it describes.
+
+**The operational picture** - what the ecosystem is doing right now:
+
+* [Egeria Operations](/user-interfaces/egeria-operations/overview) shows the status of servers, connectors, governance engines and engine actions, and supports simple commands such as refresh, restart and cancel.
+* [Egeria Audit](/user-interfaces/egeria-audit/overview) shows exceptions, certifications, licenses and users.
+* [My Egeria](/user-interfaces/my-egeria/overview) gives an individual their own view: their to-dos, meetings, reviews, roles, communities and teams, as either a terminal or browser application.
+
+Being able to see both matters more than it sounds.  A person asked to make a decision needs the structural context to understand what they are deciding about, and the operational context to know whether what they are looking at is current.
+
+## Automation needs to reach people
+
+The second half of the loop is the outbound call - and it has a range, not a single mechanism.  What is appropriate depends on how much the automation needs from the person.
+
+| Mechanism | What it asks of the recipient | Does the process wait? |
+|-----------|-------------------------------|------------------------|
+| [Notification](/concepts/notification) | Read this.  Any action is the recipient's choice. | No |
+| Notification type and subscription | Tell me when this kind of thing happens to something I care about. | No |
+| [Request for action](/concepts/request-for-action) | A survey found something that needs looking at. | Not usually |
+| [To-do](/concepts/to-do) | Do this specific thing, by this time. | Often yes |
+| [Incident report](/features/incident-reporting/overview) | Coordinate with others to resolve a situation. | Yes |
+
+A [notification](/concepts/notification) is simply a record to be read, organized into a note log - an activity log entry, a blog entry, a journal entry.  Nothing depends on the reader doing anything.
+
+A **notification type** goes further: it defines the trigger, the style of notification and the recipient, so people subscribe to the situations they care about instead of watching everything.  This is managed through the [Notification Manager](/services/omvs/notification-manager/overview) API, which links notification types to the elements being monitored and maintains the list of subscribers.  The graph below shows an engine action doing exactly this - a watchdog service maintaining the notification types for every subscription in the digital product catalog:
+
+--8<-- "snippets/actions/baudot-subscription-manager-(egeriawatchdog)-mermaid-graph.md"
+
+A **[to-do](/concepts/to-do)** is the strong form: a work item with a description, a priority, a due date and a status that moves from *requested* through *in progress* to *complete*.  It has an originator - which may be a person or a [governance action process](/concepts/governance-action-process) - and it is assigned to a [role](/concepts/person-role) rather than directly to an individual, so the work survives someone changing jobs or going on leave.  When automation raises a to-do, it is usually because it cannot proceed until the work is done.
+
+An **[incident report](/features/incident-reporting/overview)** is for situations rather than tasks: it provides a focal point for coordinating a response, accumulating the cause, the affected resources, related incidents and the actions taken, so there is a complete record afterwards.
+
+## Closing the loop
+
+An individual has no REST API to call.  So the pattern is always the same: the automation records what it needs and notifies someone; the person investigates through the user interfaces, makes the change through the APIs or a connected tool; the automation sees the change and continues.
+
+This is described in more detail under [working with people](/features/people-roles-organizations/overview/#working-with-people), and it is the basis of *stewardship*: [survey action services](/concepts/survey-action-service) produce findings, and rather than applying every finding blindly, the significant ones are put in front of a subject-matter expert who confirms or rejects them.  Even when human validation is required, the effort is far smaller than doing the work by hand - the person is reviewing a candidate answer rather than producing one.
+
+Two things make this practical at scale:
+
+* **Assignment to roles, not people.**  Because responsibilities are held as [roles](/patterns/organization-engagement/overview) with appointees, automation can address the *responsibility* and let the organization decide who currently holds it.
+* **A record of what was decided.**  The to-do, its status and the change that resulted are all in the metadata, so a decision made under time pressure can be explained later.
+
+## The same mechanisms serve AI
+
+Automation connected to Egeria is no longer only Egeria's own governance engines.  AI applications working through Egeria's APIs participate in the same loop: they read the structural and operational context from the knowledge graph, and they raise the same range of notifications and work items when they need a person - whether that is an informational message, or a decision the application is waiting on before it acts.
+
+Keeping people addressable in the same way as any other participant is what allows an organization to add AI to a process without losing the ability to say who approved what.
+
+!!! info "Related information"
+
+    * [To do](/concepts/to-do), [notification](/concepts/notification) and [request for action](/concepts/request-for-action) concepts.
+    * [Notification Manager](/services/omvs/notification-manager/overview) API - monitored resources, subscribers and notification types.
+    * [Incident reporting](/features/incident-reporting/overview) - coordinating a response to a situation.
+    * [Active Governance](/patterns/active-governance/overview) - the automation that raises this work in the first place.
+    * [Organization Engagement](/patterns/organization-engagement/overview) - roles, communities and the people the automation is calling on.
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/egeria-solutions/solution-blueprints/overview.md
+++ b/site/docs/egeria-solutions/solution-blueprints/overview.md
@@ -1,13 +1,67 @@
----
-hide:
-- toc
----
-
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright Contributors to the Egeria project. -->
 
 # Blueprints to delivery
 
---8<-- "snippets/work-in-progress.md"
+Every project produces a design.  It is usually drawn in a diagramming tool, presented to stakeholders, agreed - and then left behind, because the implementation moves on and nobody can afford to keep the picture up to date.  A year later the only accurate description of the solution is the code, and the only people who understand it are the ones who wrote it.
+
+A [solution blueprint](/concepts/solution-blueprint) is that design held as metadata instead, so that it can be linked to the implementation as it is built and to the operational picture once it is running.
+
+## What a blueprint describes
+
+A blueprint collects the [solution components](/concepts/solution-component) that together deliver a business solution, along with the roles of the people involved and the flow of data between components.
+
+It deliberately stays above the level of a UML or entity-relationship model.  It does not carry data types or cardinality; its purpose is to support a conversation - to tell the story of how the solution works to the people who need to agree on it.  An element such as a [project](/concepts/project) or a [governance definition](/concepts/governance-definition) can have several blueprints, each showing a different aspect or level of detail.
+
+The pieces are:
+
+| Element | Role in the design |
+|---------|--------------------|
+| [Solution component](/concepts/solution-component) | A part of the solution: a process, a data store, a service, a piece of infrastructure.  Components can nest, so a component in one blueprint may be a whole blueprint of its own. |
+| Solution actor role | Who interacts with a component, and in what capacity - the consumer, the subscriber, the person who maintains it. |
+| Solution ports and wires | The inputs and outputs of each component, and the links that show how data passes between them. |
+| [Information supply chain](/concepts/information-supply-chain) | The end-to-end flow of data across components, described from the business point of view. |
+
+The blueprint below describes what happens when someone subscribes to a digital product.  Notice how much of it is about *people*: the subscriber and the consumer appear alongside the pipeline and the delivery location, because a design that omits the roles does not explain how the solution actually operates.
+
+--8<-- "snippets/blueprints/digital-products/creating-a-new-subscription-to-a-digital-product-solution-blueprint-mermaid-graph.md"
+
+Each component can also be viewed in its own right, showing the blueprint it belongs to, the roles that act on it and the components it exchanges data with.  This is one component from Coco Pharmaceuticals' clinical trial solution:
+
+--8<-- "snippets/blueprints/components/analyse-patient-data-mermaid-graph.md"
+
+## From design to delivery
+
+The blueprint becomes valuable - rather than decorative - when it is connected to what is actually being built.
+
+As implementation proceeds, solution components are linked to the [digital resources](/concepts/digital-resource) that implement them using the [ImplementedBy](/types/7/0737-Solution-Implementation) relationship.  A component might be implemented by a catalogued database, an integration connector, a governance action process, or a whole subsystem.  Because these links are added as the resources appear in the catalog, the design and the implementation stay attached to each other instead of drifting apart.
+
+That linkage supports several things at once:
+
+* **Progress against the agreed design.**  Which components have implementations yet, and which are still just intent, is visible to stakeholders without asking the project for a status report.
+* **Traceability in both directions.**  From a component you can reach the resources that realize it; from a catalogued resource you can reach the design that explains why it exists and what it is supposed to do.
+* **Impact.**  When a change is proposed to a data store, the blueprint shows which parts of the solution - and which roles - depend on it.
+
+## From delivery to operation
+
+Once the solution is running, the blueprint becomes the natural place to aggregate its operational picture.  The design is already the map of what the solution consists of, so it is the right structure on which to hang what is happening:
+
+* [Lineage](/features/lineage-management/overview) captured from the running implementation shows the data actually flowing along the wires the design described.
+* Measurements and [governance metrics](/types/4/0450-Governance-Rollout) can be attached to the components and to the blueprint as a whole, so the effectiveness of the solution is reported against the same structure that was agreed at the start.
+* Exceptions and incidents raised by the implementation resolve back to the component - and therefore the role - responsible for it.
+
+In the [new systems architecture](/practices/coco-pharmaceuticals/scenarios/defining-new-systems-architecture/overview) scenario, this is exactly the argument Erin Overview makes: the blueprint makes the architecture visible to a broader audience, lets stakeholders follow the progress of the implementation because it is linked to the solution components, and once operational becomes the aggregation point for statistics about data sharing across the organization - so the teams relying on the exchange can verify that it is working.
+
+## Creating and viewing blueprints
+
+* The [Solution Architect](/services/omvs/solution-architect/overview) API maintains blueprints, solution components, ports, wires and information supply chains, and their links to the implementation.
+* [Dr.Egeria](/user-interfaces/dr-egeria/overview) lets a blueprint be authored as a Markdown document.  This is how Erin creates the *Data-Driven Systems Architecture* blueprint, and how Robbie Records documents his [data sharing hub](/practices/coco-pharmaceuticals/scenarios/patient-data-sharing-hub/overview) for stakeholders.
+* [Egeria Explorer](/user-interfaces/egeria-explorer/overview) displays blueprints and components, with the [mermaid graphs](/user-interfaces/mermaid/overview) shown above generated automatically from the metadata - which means the picture is always current, because it is drawn from the thing it describes.
+
+!!! info "Related information"
+
+    * [Model 0740 Solution Blueprints](/types/7/0740-Solution-Blueprints), [0730 Solution Components](/types/7/0730-Solution-Components), [0735 Solution Ports and Wires](/types/7/0735-Solution-Ports-and-Wires) and [0737 Solution Implementation](/types/7/0737-Solution-Implementation).
+    * [Information supply chains](/concepts/information-supply-chain) - the end-to-end data flows that blueprints describe.
+    * [Building data specifications](/egeria-solutions/building-data-specifications/overview) - the data the solution needs, specified alongside the design.
 
 --8<-- "snippets/abbr.md"


### PR DESCRIPTION
# Fill out the Evolving to the Future solutions

*Evolving to the future* follows [Leveraging your estate](https://egeria-project.org/egeria-solutions/leveraging-your-estate/): once you understand the digital resources you already have, attention turns to the transformation projects that build new capability.  The landing page and all five of its solutions were stubs carrying only a work-in-progress marker.  This PR writes them.

The framing across the section is that what holds a transformation project up is rarely the technology.  It is not being able to say precisely what data is needed; expertise that lives in people's heads; designs that drift away from what got built; the boundaries between the different kinds of data an organization keeps; and the handovers between automation and the people who make the decisions.  Each solution addresses one of these.

## Evolving to the future (landing page)

Introduces the five solutions and how they relate to each other, and hands off to *Accelerating insight* at the end.  The `hide: toc` front matter is removed now that the page has sections, matching *Keeping Safe*.

## Building data specifications

- What a data specification contains: data structures as ordered lists of data fields, with a table of the field properties that make a requirement testable - logical type and size, units and measurement uncertainty, nullability and defaults, aliases and name patterns for matching against real schemas - and the *ObjectIdentifier* classification.
- Reuse through a data dictionary, so projects select from agreed definitions rather than inventing new ones.
- Adding meaning by linking fields to glossary terms and data classes.
- From specification to implementation: matching against existing schemas, manufacturing schemas for what has to be built, and certifying conformance through *DataStructureDefinition*.
- Where else specifications are used - data sharing requests and digital product descriptions - so that requirement, request and offer share one vocabulary.

Includes the generated mermaid graphs for the *Digital Product List* data structure and for a data field reused across many data structures.

## Capturing expertise

- What is worth capturing: meaning (glossaries, terms, relationships), scope (subject areas), values (valid values, reference data, data classes), procedures (governance action processes), and the perspectives, questions and skills that give people and AI applications useful context.
- Why capture usually fails - it is organized as a documentation project alongside the real work - and how Dr.Egeria and literate governance address that, including the form-and-report round trip and lightweight crowd-sourced feedback.
- How captured definitions are put to work by attaching them to data fields, schema attributes and governed data classifications.
- Links to the subject area, glossary and common data definitions scenarios.

Includes the generated graph for a governance action process, whose description explains what each step is for.

## Blueprints to delivery

- What a blueprint describes, and why it deliberately stays above the level of a UML or E-R model: components, actor roles, ports and wires, information supply chains.
- From design to delivery - components linked to their implementations with *ImplementedBy* as those resources are catalogued, giving progress against the agreed design, two-way traceability and impact analysis.
- From delivery to operation - the blueprint as the aggregation point for lineage, measurements and governance metrics, using the argument made in the Coco Pharmaceuticals systems architecture scenario.
- How blueprints are created and viewed, including generation of the diagrams from the metadata itself.

Includes the generated graphs for the *Creating a new Subscription to a Digital Product* blueprint and for a solution component from the clinical trial blueprint.

## Crossing data boundaries

- A table of the five categories - master data, reference data, metadata, transactional data, analytics - and where each usually lives.
- What Egeria links in each, and then the joins that make cross-boundary questions answerable: glossary terms and data classes as the semantic join, data fields as the field-level join across stores, external identifiers as the identity join across tools, reference values as the coding join, and lineage and information supply chains as the flow join.
- Worked examples of questions that become queries rather than investigations, and how digital products deliver this content across the boundary into the tools that consume it.

Includes the generated graph for the master data digital product family.

## Human in the loop

- Visibility: the structural picture (The Catalog, Egeria Explorer, Lineage Explorer, mermaid graphs) and the operational picture (Egeria Operations, Egeria Audit, My Egeria).
- A table grading the ways automation reaches people by what each asks of the recipient and whether the process waits: notification, notification type and subscription, request for action, to-do, incident report.
- Closing the loop - an individual has no REST API, so the automation records what it needs, the person acts through the UIs or APIs, and the process continues - and why to-dos are assigned to roles rather than individuals.
- How AI applications connected to Egeria participate in the same loop.

Includes the generated graph for the watchdog engine action that maintains the notification types behind product subscriptions.

## Verification

`cd site && mkdocs build` completes with no warnings for any of the six pages, and the snippet includes were confirmed to render in the built HTML.

Note for anyone verifying locally: `pymdownx.snippets` resolves `--8<-- "snippets/..."` includes relative to the current directory, so the build has to be run from `site/`.  Running `mkdocs build -f site/mkdocs.yml` from the repository root silently drops every snippet include, with no warning.