### PR TITLE
Improve description of building an integraiton connector

### DIFF
--- a/site/docs/concepts/integration-connector.md
+++ b/site/docs/concepts/integration-connector.md
@@ -5,16 +5,17 @@
 
 The *integration connectors* support the exchange of metadata with third party technologies.  This exchange may be inbound and/or outbound; synchronous, polling or event-driven.
 
-An integration connector runs in an [Open Metadata Integration Service (OMIS)](/frameworks/oif/overview) which is in turn hosted in an [Integration Daemon](/concepts/integration-daemon) server.  Each integration service provides a specialist interface designed to aid the integration with a specific type of technology.  The integration connector implementation is therefore dependent on a specific OMIS.
+An integration connector is hosted in an [Integration Daemon](/concepts/integration-daemon) server.  It is built using the [Open Integration Framework (OIF)](/frameworks/oif/overview), which supplies its base classes and the *context* object that gives it access to open metadata.  A single integration connector can work with many pieces of third party technology, each one attached to it as a [catalog target](/concepts/catalog-target).
 
 ![Deployed Integration Connector](integration-connector.svg)
-> An integration connector is shown deployed in an integration service running in an integration daemon.  The connector is linking to a third party technology and also calling the open metadata APIs of Egeria to manage the exchange of metadata.
+> An integration connector is shown deployed in an integration daemon.  The connector is linking to a third party technology and also calling the open metadata APIs of Egeria to manage the exchange of metadata.
 
 
 !!! education "Further information"
     
     - [Configuring an integration connector](/guides/admin/servers/by-section/integration-daemon-services-section).
     - [Writing an integration connector](/guides/developer/integration-connectors).
+    - [Supporting catalog targets](/guides/developer/integration-connectors/catalog-targets).
     - [Open Connector Framework (OCF)](/frameworks/ocf/overview).
 
 ---8<-- "snippets/abbr.md"

--- a/site/docs/guides/developer/integration-connectors/catalog-targets.md
+++ b/site/docs/guides/developer/integration-connectors/catalog-targets.md
@@ -1,0 +1,331 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+# Supporting catalog targets
+
+A [catalog target](/concepts/catalog-target) describes a specific piece of third party technology that an [integration connector](/concepts/integration-connector) is exchanging metadata with.
+
+## Why catalog targets change the way connectors are built
+
+Originally, the technology that an integration connector worked with was identified by the [endpoint](/concepts/endpoint) in the connector's own [connection](/concepts/connection).  A connection describes one endpoint, so a connector instance could work with exactly one database, one file directory, or one Kafka broker.  If you had three databases to catalog, you configured and deployed three instances of the connector, each with its own connection, its own credentials and its own entry in the integration daemon's configuration.
+
+With catalog targets, the connector's connection only needs to identify the connector implementation.  The technology to work with is attached to the connector's *IntegrationConnector* metadata element using a [*CatalogTarget*](/types/4/0464-Dynamic-Integration-Groups) relationship that points at the [asset](/concepts/asset) describing the technology.
+
+![Database cataloguing integration connector](/services/omvs/asset-maker/integration-connector-catalog-target-database-example.svg)
+> The integration connector is linked to the asset for the database it is to catalog.  The asset's own connection - including any embedded secrets store connector - is used to create the connector that calls the database.
+
+This has a big effect on operations:
+
+* The connector is deployed once - typically by loading a [content pack](/content-packs) into the metadata access store at start up - and it then runs in an [integration group](/concepts/integration-group).
+* When someone wants a new database catalogued, they attach the database's asset to the connector with a *CatalogTarget* relationship.  No configuration change, no restart.
+* Connection details, including credentials, are defined once on the asset and reused by every connector, [survey action service](/concepts/survey-action-service) and [governance action service](/concepts/governance-action-service) that works with that resource.
+* Each catalog target can carry its own configuration properties, templates, metadata source name and permitted synchronization, so one running connector can treat each of its targets differently.
+
+It also changes the way the connector is built.  The per-resource logic that used to live in the connector's `refresh()` method moves into a *catalog target processor*.
+
+## The shape of a catalog target connector
+
+```mermaid
+flowchart TD
+    subgraph one["Integration daemon thread"]
+    A["`**MyIntegrationConnector**
+    _extends DynamicIntegrationConnectorBase_
+    start(), refresh(), disconnect()`"]
+    end
+    A -->|"getNewRequestedCatalogTargetSkeleton()"| B["`**MyCatalogTargetProcessor**
+    _extends CatalogTargetProcessorBase_
+    catalog target: *sales database*`"]
+    A --> C["`**MyCatalogTargetProcessor**
+    catalog target: *finance database*`"]
+    A --> D["`**MyCatalogTargetProcessor**
+    catalog target: *HR database*`"]
+```
+
+There are two classes to write (plus the [connector provider](/guides/developer/integration-connectors/#writing-the-connector-provider)):
+
+| Class | Extends | Responsibility |
+|---|---|---|
+| The integration connector | `DynamicIntegrationConnectorBase` | Extract any connector-wide configuration in `start()`, and act as a factory that creates a processor for each catalog target. |
+| The catalog target processor | `CatalogTargetProcessorBase` | All the work for one piece of third party technology: validate the target, call the technology, and maintain the open metadata for it. |
+
+The base class does the rest.  On each `refresh()` it:
+
+1. Retrieves the current list of *CatalogTarget* relationships attached to the connector's element.
+2. For each new one, creates a [digital resource connector](/concepts/digital-resource-connector) for the target asset (if the target is an asset with a connection), calls your `getNewRequestedCatalogTargetSkeleton()` method to create the processor, overlays the configuration properties, starts the resource connector and calls `start()` on the processor.
+3. For each one whose relationship properties have changed, disconnects the old resource connector and repeats step 2 with the new values.
+4. Calls `refresh()` on every processor, catching and logging exceptions so that one failing target does not stop the others.
+5. Registers an open metadata event listener (once the first refresh is complete) if the connector implements `OpenMetadataEventListener`, and passes each event to any processor that implements `OpenMetadataEventListener`.
+
+## Writing the integration connector
+
+The connector extends [`DynamicIntegrationConnectorBase` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/DynamicIntegrationConnectorBase.java){ target=gh } and implements a single abstract method: `getNewRequestedCatalogTargetSkeleton()`.  Here is the complete implementation of the [Kafka Topic Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/system-connectors/apache-kafka-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/apachekafka/integration/KafkaTopicIntegrationConnector.java){ target=gh }:
+
+```java
+public class KafkaTopicIntegrationConnector extends DynamicIntegrationConnectorBase
+{
+    /**
+     * Create a new catalog target processor (typically inherits from CatalogTargetProcessorBase).
+     *
+     * @param retrievedCatalogTarget details of the open metadata elements describing the catalog target
+     * @param catalogTargetContext   specialized context for this catalog target
+     * @param connectorToTarget      connector to access the target resource
+     * @return new processor based on the catalog target information
+     */
+    @Override
+    public RequestedCatalogTarget getNewRequestedCatalogTargetSkeleton(CatalogTarget        retrievedCatalogTarget,
+                                                                       CatalogTargetContext catalogTargetContext,
+                                                                       Connector            connectorToTarget)
+    {
+        return new KafkaTopicCatalogTargetProcessor(retrievedCatalogTarget,
+                                                    catalogTargetContext,
+                                                    connectorToTarget,
+                                                    connectorName,
+                                                    auditLog);
+    }
+}
+```
+
+Notice that there is no `start()`, `refresh()` or `disconnect()` method.  They are only needed if the connector has work of its own to do.  For example, the [PostgreSQL Server Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/postgres/catalog/PostgresServerIntegrationConnector.java){ target=gh } overrides `start()` to read the default database include/exclude lists from its own connection:
+
+```java
+    @Override
+    public void start() throws ConnectorCheckedException, UserNotAuthorizedException
+    {
+        super.start();
+
+        defaultExcludeDatabases = super.getArrayConfigurationProperty(PostgresConfigurationProperty.EXCLUDE_DATABASE_LIST.getName(),
+                                                                      connectionBean.getConfigurationProperties(),
+                                                                      Collections.singletonList("postgres"));
+        :
+    }
+```
+
+!!! attention "Always call the superclass method"
+    `super.start()` creates the catalog targets manager, `super.refresh()` drives the catalog target processors, and `super.disconnect()` releases their resource connectors.  If you override any of these methods without calling the superclass version, your catalog targets are never processed.
+
+## Writing the catalog target processor
+
+The processor extends [`CatalogTargetProcessorBase` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/CatalogTargetProcessorBase.java){ target=gh }, which in turn extends `RequestedCatalogTarget` and `CatalogTarget`.  This means the properties of the catalog target are available directly on `this`:
+
+| Method | Description |
+|---|---|
+| `getCatalogTargetName()` | The name given to this target by the person who attached it.  Use it in audit log messages so operators can tell the targets apart. |
+| `getCatalogTargetElement()` | The `OpenMetadataRootElement` for the element at the other end of the *CatalogTarget* relationship, including its classifications, its attached software capabilities and its related elements. |
+| `getConnectorToTarget()` | The [digital resource connector](/concepts/digital-resource-connector) created from the target asset's connection, already started.  It is null if the target is not an asset, or has no connection. |
+| `getConfigurationProperties()` | The connector's own configuration properties, overlaid with the configuration properties from the *CatalogTarget* relationship.  The relationship's values win. |
+| `getTemplates()` | Map of template name to template GUID for [templated cataloguing](/features/templated-cataloguing/overview). |
+| `getPermittedSynchronization()` | The direction metadata is allowed to flow for this target.  Defaults to the connector's setting. |
+| `getMetadataSourceQualifiedName()` | The qualified name of the [software capability](/concepts/software-capability) that owns the metadata created for this target. |
+| `getDeleteMethod()` | Whether deletes for this target should be soft-deletes, archives or purges. |
+| `getRelationshipGUID()` | Unique identifier of the *CatalogTarget* relationship itself - useful if the connector needs to update it. |
+| `integrationContext` | The [`CatalogTargetContext`](/guides/developer/integration-connectors/integration-context) for this target.  It is already set up with the correct metadata source and permitted synchronization. |
+
+### The start method
+
+`start()` is called once, when the catalog target is first seen (and again if the relationship is updated).  This is where to validate the target and extract the values that do not change between refreshes.  From the [Kafka Topic Catalog Target Processor :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/system-connectors/apache-kafka-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/apachekafka/integration/KafkaTopicCatalogTargetProcessor.java){ target=gh }:
+
+```java
+    @Override
+    public void start() throws UserNotAuthorizedException, ConnectorCheckedException
+    {
+        super.start();
+
+        final String methodName = "start";
+
+        integrationContext.validateIsActive(methodName);
+
+        if ((super.connectorToTarget != null) &&
+            (super.connectorToTarget.getConnection() != null) &&
+            (super.connectorToTarget.getConnection().getEndpoint() != null) &&
+            (super.connectorToTarget.getConnection().getEndpoint().getNetworkAddress() != null))
+        {
+            hostIdentifier = super.getHostIdentifier(super.connectorToTarget.getConnection().getEndpoint().getNetworkAddress());
+            portNumber     = super.getPortNumber(super.connectorToTarget.getConnection().getEndpoint().getNetworkAddress());
+            templateGUID   = this.getTemplateGUID();
+        }
+        else
+        {
+            super.throwMissingConnectionInfo(OpenMetadataProperty.NETWORK_ADDRESS.name, methodName);
+        }
+
+        if (propertyHelper.isTypeOf(this.getCatalogTargetElement().getElementHeader(), OpenMetadataType.SOFTWARE_SERVER.typeName))
+        {
+            eventBrokerGUID = this.getEventBrokerGUID(this.getCatalogTargetElement());
+        }
+        else if (propertyHelper.isTypeOf(this.getCatalogTargetElement().getElementHeader(), OpenMetadataType.EVENT_BROKER.typeName))
+        {
+            eventBrokerGUID = this.getCatalogTargetElement().getElementHeader().getGUID();
+        }
+        else
+        {
+            super.throwWrongTypeOfCatalogTarget(Arrays.asList(OpenMetadataType.SOFTWARE_SERVER.typeName,
+                                                              OpenMetadataType.EVENT_BROKER.typeName).toString(),
+                                                methodName);
+        }
+    }
+```
+
+`CatalogTargetProcessorBase` supplies a family of helper methods for this validation work, so that all connectors report the same problems in the same way:
+
+* `throwWrongTypeOfCatalogTarget()` - the element on the end of the relationship is not a type this connector can process.
+* `throwWrongTypeOfResourceConnector()` - the asset's connection created a connector of an unexpected class.
+* `throwMissingConnectionInfo()` - the connection is missing a value the connector needs, such as the network address.
+* `throwMissingPropertyValue()` and `throwBadBeanClass()` - the target element does not have the properties the connector expects.
+
+It also supplies methods to extract typed values from the combined configuration properties - `getStringConfigurationProperty()`, `getBooleanConfigurationProperty()`, `getIntConfigurationProperty()`, `getLongConfigurationProperty()`, `getDateConfigurationProperty()`, `getArrayConfigurationProperty()` and `getSuppliedPlaceholderProperties()` - along with `getHostIdentifier()` and `getPortNumber()` for splitting a network address.
+
+### The refresh method
+
+`refresh()` does the metadata exchange for this one target.  Because the base class calls it inside a try/catch, an exception thrown here takes only this target out of action for this pass, not the whole connector.
+
+```java
+    @Override
+    public void refresh() throws ConnectorCheckedException
+    {
+        final String methodName = "refresh";
+
+        if (propertyHelper.isTypeOf(this.getCatalogTargetElement().getElementHeader(),
+                                    PostgresDeployedImplementationType.POSTGRESQL_SERVER.getAssociatedTypeName()))
+        {
+            JDBCResourceConnector assetConnector = null;
+
+            try
+            {
+                String                  databaseServerGUID = this.getCatalogTargetElement().getElementHeader().getGUID();
+                OpenMetadataRootElement databaseManager    = this.getDatabaseManager(databaseServerGUID, this.getCatalogTargetElement());
+
+                Connector connector = integrationContext.getConnectedAssetContext().getConnectorForAsset(databaseServerGUID, auditLog);
+
+                assetConnector = (JDBCResourceConnector)connector;
+                assetConnector.start();
+
+                catalogDatabases(databaseServerGUID,
+                                 databaseManager,
+                                 this.getTemplates(),
+                                 this.getConfigurationProperties(),
+                                 assetConnector);
+            }
+            catch (Exception exception)
+            {
+                auditLog.logException(methodName,
+                                      PostgresAuditCode.UNEXPECTED_EXCEPTION.getMessageDefinition(connectorName,
+                                                                                                  exception.getClass().getName(),
+                                                                                                  methodName,
+                                                                                                  exception.getMessage()),
+                                      exception);
+            }
+            finally
+            {
+                this.releaseAssetConnector(assetConnector, methodName);
+            }
+        }
+        else
+        {
+            super.throwWrongTypeOfCatalogTarget(PostgresDeployedImplementationType.POSTGRESQL_SERVER.getAssociatedTypeName(),
+                                                methodName);
+        }
+    }
+```
+
+!!! tip "Release any connector you create yourself"
+    The resource connector returned by `getConnectorToTarget()` is managed by the base class - do not disconnect it.  However, if `refresh()` creates its own connector (as the PostgreSQL example does, to pick up a fresh database session each pass) it must release it on both the success and the failure path.  Otherwise each failed refresh leaks the connector and the connections it holds.
+
+### The disconnect method
+
+`disconnect()` is called when the *CatalogTarget* relationship is removed, or when the connector shuts down.  Free up any resources that this processor holds.  The resource connector supplied by the base class is disconnected for you.
+
+### Processing events for a catalog target
+
+If the catalog target processor implements [`OpenMetadataEventListener` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-metadata-framework/src/main/java/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataEventListener.java){ target=gh }, it is passed each event from the open metadata ecosystem.
+
+For this to happen, the *integration connector* must also implement `OpenMetadataEventListener` - this is the signal that the connector is interested in open metadata events.  `DynamicIntegrationConnectorBase` provides the `processEvent()` implementation that fans the event out to the processors, and registers the listener at the end of the first `refresh()`.  The delay is deliberate: it avoids a flood of events caused by the connector's own initial synchronization.  The listener is only registered if the permitted synchronization allows metadata to flow to the third party technology.
+
+```java
+public class MyIntegrationConnector extends DynamicIntegrationConnectorBase implements OpenMetadataEventListener
+{
+    // processEvent() is inherited from DynamicIntegrationConnectorBase
+}
+
+public class MyCatalogTargetProcessor extends CatalogTargetProcessorBase implements OpenMetadataEventListener
+{
+    @Override
+    public void processEvent(OpenMetadataOutTopicEvent event)
+    {
+        // called for each open metadata event, for this catalog target
+    }
+}
+```
+
+The base class only passes events on when a refresh is not running, so your `processEvent()` method does not have to test `integrationContext.noRefreshInProgress()` itself.
+
+Events from the *third party* technology are handled differently: register the listener in the processor's constructor or `start()` method.  The [OpenLineage Event Receiver Catalog Target Processor :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/openlineage-integration-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/openlineage/OpenLineageEventReceiverCatalogTargetProcessor.java){ target=gh } has an [Open Metadata Topic Connector](/concepts/open-metadata-topic-connector) as its target resource connector, and registers a listener with it:
+
+```java
+    public OpenLineageEventReceiverCatalogTargetProcessor(CatalogTarget             template,
+                                                          CatalogTargetContext      catalogTargetContext,
+                                                          Connector                 connectorToTarget,
+                                                          String                    connectorName,
+                                                          AuditLog                  auditLog,
+                                                          OpenMetadataTopicListener listener) throws ConnectorCheckedException,
+                                                                                                     UserNotAuthorizedException
+    {
+        super(template, catalogTargetContext, connectorToTarget, connectorName, auditLog);
+
+        if (super.getConnectorToTarget() instanceof OpenMetadataTopicConnector topicConnector)
+        {
+            topicConnector.registerListener(listener);
+
+            if (! topicConnector.isActive())
+            {
+                topicConnector.start();
+            }
+        }
+    }
+```
+
+Its `refresh()` method does nothing, because all of its work is event-driven.
+
+### Being notified when the catalog targets change
+
+An integration connector that needs to know when its catalog targets are added, changed or removed can implement [`CatalogTargetChangeListener` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/CatalogTargetChangeListener.java){ target=gh } and register it with the catalog targets manager:
+
+```java
+        catalogTargetsManager.registerCatalogTargetChangeListener(this);
+```
+
+The interface has `newCatalogTarget()`, `updatedCatalogTarget()` and `removedCatalogTarget()` methods.  Most connectors do not need this, since the processor's own `start()` and `disconnect()` methods cover the same events.
+
+## Declaring the supported catalog target types
+
+The [connector provider](/guides/developer/integration-connectors/#writing-the-connector-provider) declares which types of element this connector accepts as a catalog target.  This information is published in open metadata so that the tools people use to attach catalog targets can offer the right choices, and so that they can be validated.  See [defining the catalog target types](/guides/developer/integration-connectors/#catalog-target-types).
+
+## Naming the metadata source
+
+Each catalog target can name the [software capability](/concepts/software-capability) that acts as the [metadata collection](/concepts/metadata-collection) for the metadata created from it - the `metadataSourceQualifiedName` property on the *CatalogTarget* relationship.  This means metadata from the sales database and metadata from the finance database can be held in separate metadata collections, even though a single connector instance created both.
+
+`CatalogTargetProcessorBase` provides `setUpMetadataSource()` and `setUpSoftwareCapability()` to locate (or create) these elements.  The [external source metadata provenance](/features/metadata-provenance/overview) that results prevents other tools from changing the metadata that this connector maintains.
+
+## Migrating an existing connector
+
+To convert a connector that predates catalog targets:
+
+1. Change the superclass from `IntegrationConnectorBase` (or one of the old `XXXIntegratorConnector` classes) to `DynamicIntegrationConnectorBase`.
+2. Create a new class extending `CatalogTargetProcessorBase` and move the body of `refresh()` into it, along with any instance variables it uses.
+3. Move the parts of `start()` that relate to a specific resource into the processor's `start()` method.  Anything that reads the connector's own configuration stays behind.
+4. Implement `getNewRequestedCatalogTargetSkeleton()` on the connector to return an instance of the new processor.
+5. Replace `getContext()` with the `integrationContext` variable, and `connectionProperties` with `connectionBean`.
+6. Replace direct use of the endpoint from the connector's connection with `getConnectorToTarget()`, or with the network address from the target asset's connection.
+7. Declare the supported catalog target types in the connector provider.
+
+???+ info "Code examples"
+    * [Kafka Topic Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/system-connectors/apache-kafka-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/apachekafka/integration/KafkaTopicIntegrationConnector.java){ target=gh } - the smallest complete example.
+    * [PostgreSQL Server Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/postgres/catalog/PostgresServerIntegrationConnector.java){ target=gh } - configuration properties, templates and a resource connector.
+    * [Unity Catalog Server Sync Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/unity-catalog-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/unitycatalog/sync/OSSUnityCatalogServerSyncConnector.java){ target=gh } - two-way synchronization using the [integration iterators](/guides/developer/integration-connectors/integration-context/#integration-iterators).
+    * [OpenLineage Event Receiver Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/openlineage-integration-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/openlineage/OpenLineageEventReceiverIntegrationConnector.java){ target=gh } - event-driven catalog targets.
+
+??? education "Further information"
+    - [Catalog target](/concepts/catalog-target) concept page.
+    - [Integration group](/concepts/integration-group) - how connectors and their catalog targets are described in open metadata.
+    - [Self-registering integration connectors](/guides/developer/integration-connectors/self-registering-integration-connectors) - connectors that find and attach their own catalog targets.
+
+--8<-- "snippets/abbr.md"

--- a/site/docs/guides/developer/integration-connectors/implementing-an-integration-connector-provider.md
+++ b/site/docs/guides/developer/integration-connectors/implementing-an-integration-connector-provider.md
@@ -2,96 +2,106 @@
 <!-- Copyright Contributors to the ODPi Egeria project. -->
 
 
-Each connector provider for an integration connector extends the [IntegrationConnectorProvider](https://odpi.github.io/egeria/org/odpi/openmetadata/governanceservers/integrationdaemonservices/connectors/IntegrationConnectorProvider.html) base class, which in turn extends the standard `ConnectorProviderBase`:
+Each connector provider for an integration connector extends the [`IntegrationConnectorProvider` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/IntegrationConnectorProvider.java){ target=gh } base class, which in turn extends `OpenConnectorProviderBase` and `ConnectorProviderBase`.
 
-This assumes the integration connector's implementation class is instantiated via the default constructor and all of its configuration information is contained in the [Connection](/concepts/connection) object supplied on the `initialize()` method.
+This assumes the integration connector's implementation class is instantiated via the default constructor and all of its configuration information is contained in the [Connection](/concepts/connection) object supplied on the `initialize()` method, plus the [catalog targets](/concepts/catalog-target) attached to it at runtime.
 
-If your connector implementation matches these requirements, its connector provider implementation need only implement a constructor to configure the base class's function with details of itself and the Java class of the connector it needs using:
-               
-- a GUID for the [connector type](/concepts/connector-type)
-- a name for the connector type.
-- a description of what the connector is for and how to configure it.
+The descriptive information about the connector is supplied through an implementation of the [`OpenConnectorDefinition` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-connector-framework/src/main/java/org/odpi/openmetadata/frameworks/connectors/OpenConnectorDefinition.java){ target=gh } interface.  Defining it as an enum keeps the descriptions of all the connectors in your library together, and makes it easy to generate an open metadata archive that describes them.  Egeria's own connectors use the `EgeriaOpenConnectorDefinition` enum for this.
+
+The definition supplies:
+
+- a GUID for the [connector type](/concepts/connector-type), and its qualified name, display name and description.
+- a unique component identifier and wiki page used in the connector's audit log messages (Egeria uses numbers under 1000 for its own connectors, so choose a number above that).
+- the class name of the connector provider, and the development status of the connector.
+- the open metadata type and [deployed implementation type](/concepts/deployed-implementation-type) of the asset that a connection for this connector should be linked to.
+
+The connector provider's constructor then adds the information that is specific to integration connectors:
+
 - the connector class it instantiates.
-- a list of the additional properties, configuration properties and secured properties needed to configure instances of the connector.
-- a description of the connector for its audit log (if the connector implements `AuditLoggingComponent`).
+- the names of the configuration properties it recognizes, and their full descriptions.
+- the types of element it accepts as a [catalog target](/concepts/catalog-target).
+- the technology types it supports, and any templates it uses.
+- optionally, the default refresh interval and whether the connector issues blocking calls.
 
 ```java
 /**
- * XXXStoreProvider is the OCF connector provider for the XXX integration connector.
+ * XXXStoreProvider is the connector provider for the XXX integration connector.
  */
-public class XXXStoreProvider extends IntegrationConnectorProviderBase
+public class XXXStoreProvider extends IntegrationConnectorProvider
 {
     /*
-     * Unique identifier of the connector for the audit log.
-     */
-    private static final int    connectorComponentId   = 10001; /* Add unique number here - Egeria uses numbers under 1000 */
-
-    /*
-     * Unique identifier for the connector type.
-     */
-    private static final String connectorTypeGUID      = "Add unique GUID here";
-
-    /*
-     * Descriptive information about the connector for the connector type and audit log.
-     */
-    private static final String connectorQualifiedName = "MyOrg:Integration:XXXStoreConnector";
-    private static final String connectorDisplayName   = "XXX Store Connector";
-    private static final String connectorDescription   = "Connector supports ... add details here.";
-    private static final String connectorWikiPage      = "Add url to documentation here";
-
-
-    /*
-     * Define the name of the connector implementation.
+     * Class of the connector implementation.
      */
     private static final String connectorClassName = "packagename.XXXStoreConnector";
-    
-    /*
-     * Define the name of configuration properties (optional).
-     */
-    public static final String TEMPLATE_QUALIFIED_NAME_CONFIGURATION_PROPERTY = "templateQualifiedName";
+
 
     /**
-     * Constructor used to initialize the ConnectorProviderBase class.
+     * Constructor used to initialize the base class with details of this connector.
      */
     public XXXStoreProvider()
     {
-        super();
+        super(MyOpenConnectorDefinition.XXX_STORE_INTEGRATION_CONNECTOR,
+              connectorClassName,
+              XXXConfigurationProperty.getRecognizedConfigurationProperties());
 
         /*
-         * Set up the class name of the connector that this provider creates.
+         * The technology that this connector works with.
          */
-        super.setConnectorClassName(connectorClassName);
+        super.supportedTechnologyTypes = SupportedTechnologyType.getSupportedTechnologyTypes(
+                new DeployedImplementationTypeDefinition[]{XXXDeployedImplementationType.XXX_SERVER});
 
         /*
-         * Set up the connector type that should be included in a connection used to configure this connector.
+         * The types of element that can be attached to this connector as a catalog target.
          */
-        ConnectorType connectorType = new ConnectorType();
-        connectorType.setType(ConnectorType.getConnectorTypeType());
-        connectorType.setGUID(connectorTypeGUID);
-        connectorType.setQualifiedName(connectorQualifiedName);
-        connectorType.setDisplayName(connectorDisplayName);
-        connectorType.setDescription(connectorDescription);
-        connectorType.setConnectorProviderClassName(this.getClass().getName());
+        super.catalogTargets = XXXTarget.getCatalogTargetTypes();
 
-        List<String> recognizedConfigurationProperties = new ArrayList<>();
-        recognizedConfigurationProperties.add(TEMPLATE_QUALIFIED_NAME_CONFIGURATION_PROPERTY);
-        connectorType.setRecognizedConfigurationProperties(recognizedConfigurationProperties);
- 
-        super.connectorTypeBean = connectorType;
- 
         /*
-         * Set up the component description used in the connector's audit log messages.
+         * Full descriptions of the configuration properties, for the person deploying the connector.
          */
-        AuditLogReportingComponent componentDescription = new AuditLogReportingComponent();
- 
-        componentDescription.setComponentId(connectorComponentId);
-        componentDescription.setComponentName(connectorQualifiedName);
-        componentDescription.setComponentDescription(connectorDescription);
-        componentDescription.setComponentWikiURL(connectorWikiPage);
- 
-        super.setConnectorComponentDescription(componentDescription);
+        super.supportedConfigurationProperties = XXXConfigurationProperty.getConfigurationPropertyTypes();
+
+        /*
+         * Optional: how often refresh() should be called, in minutes.  Zero means only at start up
+         * and when explicitly requested.  The default is 60.
+         */
+        super.setRefreshTimeInterval(30L);
     }
 }
 ```
 
+### Catalog target types
+
+The `catalogTargets` list tells the people (and the tools) that deploy this connector which elements it can work with.  Each [`CatalogTargetType` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/controls/CatalogTargetType.java){ target=gh } has:
+
+* **name** - the *catalogTargetName* used on the *CatalogTarget* relationship.  A connector that accepts more than one kind of target uses this name to tell them apart.
+* **typeName** - the [open metadata type](/types) of the element, such as `SoftwareServer` or `DataFolder`.
+* **deployedImplementationType** - a more precise description of the technology, such as `PostgreSQL Server`.
+* **otherPropertyValues** - additional property values that a compatible catalog target should have.
+
+These are typically defined as an enum alongside the connector.  From the PostgreSQL connectors:
+
+```java
+public enum PostgresTarget
+{
+    SERVER("postgreSQLServer",
+           PostgresDeployedImplementationType.POSTGRESQL_SERVER.getDescription(),
+           PostgresDeployedImplementationType.POSTGRESQL_SERVER.getAssociatedTypeName(),
+           PostgresDeployedImplementationType.POSTGRESQL_SERVER.getDeployedImplementationType(),
+           null),
+
+    DATABASE("postgresDatabase",
+             PostgresDeployedImplementationType.POSTGRESQL_DATABASE.getDescription(),
+             PostgresDeployedImplementationType.POSTGRESQL_DATABASE.getAssociatedTypeName(),
+             PostgresDeployedImplementationType.POSTGRESQL_DATABASE.getDeployedImplementationType(),
+             null),
+    ;
+}
+```
+
+The catalog target processor should still validate the element it is given, since the relationship can be created by anyone - see [writing the catalog target processor](/guides/developer/integration-connectors/catalog-targets/#writing-the-catalog-target-processor).
+
+### Refresh interval and blocking calls
+
+- `setRefreshTimeInterval(minutes)` sets the default number of minutes between calls to `refresh()`.  Zero means `refresh()` is only called at start up and when an operator explicitly requests it.  The value can be overridden in the connector's configuration.
+- `setUsesBlockingCalls(true)` tells the integration daemon to run the connector on its own thread and to call `engage()` rather than `refresh()`.
 

--- a/site/docs/guides/developer/integration-connectors/index.md
+++ b/site/docs/guides/developer/integration-connectors/index.md
@@ -3,13 +3,17 @@
 
 # Building Integration Connectors
 
----8<-- "snippets/connectors/integration-connector-intro.md"
+The [integration connectors](/concepts/integration-connector) support the exchange of metadata with third party technologies.  This exchange may be inbound and/or outbound; synchronous, polling or event-driven.
+
+![Deployed Integration Connector](/concepts/integration-connector.svg)
+> An integration connector is shown deployed in an integration daemon.  The connector is linking to a third party technology and also calling the open metadata APIs of Egeria to manage the exchange of metadata.
 
 The purpose of the [integration daemon](/concepts/integration-daemon) is to minimise the effort required to integrate a third party technology into the open metadata ecosystem.  They handle:
 
 * Management of configuration - including user security information.
 * Starting and stopping of your integration logic.
 * Thread management and polling.
+* Discovering which pieces of third party technology your connector should be working with, and keeping that list up to date.
 * Access to the open metadata repositories for query and maintenance of open metadata.
 * Ability to write to audit log and maintain measurements for performance metrics.
 * Metadata provenance.
@@ -27,28 +31,59 @@ Integration connectors are also useful for tasks that need to run regularly.  Eg
 
 There are five main design decisions to make before you start coding:
 
-* How is the work of the connector triggered - explicitly through the connection object contents or by listening for events from either the third party technology or open metadata?
-* Which direction the metadata synchronization is going.  Is the third party technology the source of metadata or is metadata the open metadata ecosystem being pushed to the third party technology?  
-* How are elements from the third party technology mapped to and correlated with the elements in open metadata.
-* If the third party technology is the source, should the metadata created in the open metadata ecosystem be read-only so that it can not be changed by other tools.  This is achieved using [External source metadata provenance](/features/metadata-provenance/overview).
-* How is the third party technology to be called?  Ideally, your 
+* How does the connector find out which pieces of third party technology to work with?  In almost all cases the answer is [catalog targets](/guides/developer/integration-connectors/catalog-targets), which allow a single deployed connector to work with many resources, added and removed while it runs.
+* How is the work of the connector triggered - by polling on the `refresh()` call, by listening for events from the third party technology, or by listening for events from open metadata?
+* Which direction the metadata synchronization is going.  Is the third party technology the source of metadata, or is metadata from the open metadata ecosystem being pushed to the third party technology?
+* How are elements from the third party technology mapped to and correlated with the elements in open metadata?
+* If the third party technology is the source, should the metadata created in the open metadata ecosystem be read-only so that it can not be changed by other tools?  This is achieved using [External source metadata provenance](/features/metadata-provenance/overview).
 
-### Three patterns for connections
+### Identifying the technology to work with
 
-Your integration connector is created and initialized with a connection object.  This connection object should contain all the configuration needed by your integration connector.  For example, it may contain configuration properties that can control the behavior of your connector.  When connecting to the third party technology, optional userId and password for the third party technology may be stored in the connection along with endpoint information that defines the network address of its deployment.
+Your integration connector is created and initialized with a connection object.  This connection object should contain the configuration needed by your integration connector.  For example, it may contain configuration properties that control the behavior of your connector.
 
-![Connection object with an explicit endpoint](explicit-endpoints.svg)
-> An explicit endpoint is added to the integration connector's connection in its configuration to provide information on the network location of the third party technology.  This is used to initialize the client libraries needed to call the third party technology.
+There are three patterns for identifying the third party technology that the connector is to work with.
 
-![A connection with no endpoint](learned-endpoints.svg)
-> If no endpoint is configured in the integration connector's connection, the endpoint information can be retrieved from open metadata by calling the context object and/or listening for notifications from the partner OMAS.
+=== "Catalog targets (recommended)"
 
-An alternative approach to calling the third party technology directly in your integration connector is to use one or more appropriate [digital resource connectors](/concepts/digital-resource-connector) to call the third party technology.  The connection objects for these digital resource connectors are embedded in the connection object for the integration connector.  
+    The technology to work with is attached to the connector's *IntegrationConnector* element with a [*CatalogTarget*](/types/4/0464-Dynamic-Integration-Groups) relationship.
+
+    ![Integration connector with catalog targets](/services/omvs/asset-maker/integration-connector-catalog-target.svg)
+    > The connection for the integration connector just needs the connector type that describes its implementation.  The *CatalogTarget* relationship links to the asset that describes the technology the connector is to work with.  There can be many of them, and they can be added and removed while the connector is running.
+
+    The connector is deployed once - typically by loading a [content pack](/content-packs) at start up - and people then attach the resources they want it to work with.  Connection details and credentials are defined once, on the asset, and reused by every connector, [survey action service](/concepts/survey-action-service) and [governance action service](/concepts/governance-action-service) that works with that resource.
+
+    See [supporting catalog targets](/guides/developer/integration-connectors/catalog-targets).
+
+=== "An explicit endpoint"
+
+    ![Connection object with an explicit endpoint](explicit-endpoints.svg)
+    > An explicit endpoint is added to the integration connector's connection in its configuration to provide information on the network location of the third party technology.  This is used to initialize the client libraries needed to call the third party technology.
+
+    This is the original pattern.  It ties one running connector instance to one piece of technology: to monitor three databases you deploy three configured instances.  Use it only where the connector genuinely has a single fixed destination - for example, a connector that writes a log of open lineage events to a particular file system.
+
+=== "A learned endpoint"
+
+    ![A connection with no endpoint](learned-endpoints.svg)
+    > If no endpoint is configured in the integration connector's connection, the endpoint information can be retrieved from open metadata by calling the context object and/or listening for notifications from open metadata.
+
+    A [self-registering integration connector](/guides/developer/integration-connectors/self-registering-integration-connectors) takes this further: it searches open metadata for the elements it is interested in and attaches them to itself as catalog targets.
+
+### Calling the third party technology
+
+An alternative to calling the third party technology directly from your integration connector is to use one or more appropriate [digital resource connectors](/concepts/digital-resource-connector).
+
+When your connector works with catalog targets, this is done for you.  If the catalog target is an [asset](/concepts/asset) with a connection, the framework creates and starts the resource connector, and it is available from the catalog target processor's `getConnectorToTarget()` method.  This is the recommended approach: the credentials live on the asset, in one place, and are shared with every other governance service that works with that resource.
+
+Where the connector needs a resource connector for an asset that is not its catalog target, `integrationContext.getConnectedAssetContext().getConnectorForAsset(assetGUID, auditLog)` creates one.
+
+Connection objects for digital resource connectors can also be embedded in the connection object for the integration connector itself.
 
 ![A virtual connection include embedded connection](virtual-connector.svg)
-> A [Virtual Connection](/concepts/connection/#virtual-connections) is a special type of connection that allows connections for different connectors to be embedded.  This style of connection can be used by an integration connector that is making use of digital resource connectors to call its third party technology.  Typically, there is only one embedded connection, but multiple embedded connections can be used.  Also, the embedded connections themselves may be virtual connections.
+> A [Virtual Connection](/concepts/connection/#virtual-connections) is a special type of connection that allows connections for different connectors to be embedded.  Typically, there is only one embedded connection - a [secrets store connector](/concepts/secrets-store-connector) is the most common - but multiple embedded connections can be used.  Also, the embedded connections themselves may be virtual connections.
 
-Embedding a digital resource connector in an integration connector is an ideal approach for working with any third party technology that is being catalogued as assets:
+When the digital resource connectors are defined in a virtual connection (rather than being initialized in the integration connector logic), the integration daemon can manage the lifecycle of the embedded connectors with the lifecycle of the integration connectors, reducing the chances of memory leaks and held resources as the connectors/integration daemon are restarted over the lifetime of their hosting OMAG Server Platform.  The embedded connectors are available through the `embeddedConnectors` variable.
+
+Sharing a resource connector is not always possible.  It works well when the same interface serves both the metadata and the data:
 
 * Consumers of the digital resources in the third party technology need a digital resource connector to access the content of the digital resource.  It may be possible to use the same digital resource connector in the integration connector.
 * Often, the integration connector is not the only connector that is accessing a particular third party technology.  There may be [survey action services](/concepts/survey-action-service) and [governance action services](/concepts/governance-action-service) that also need to access the third party technology once the integration connector has run to create the basic technical metadata.
@@ -57,13 +92,11 @@ For example, Egeria has a JDBC digital resource connector for accessing database
 
 ![Multiple uses of the JDBC digital resource connector](/connectors/jdbc-connectors.svg)
 
-When the digital resource connectors are defined in a virtual connection (rather than being initialized in the integration connector logic), the integration daemon can manage the lifecycle of the embedded connectors with the lifecycle of the integration connectors, reducing the chances of memory leaks and held resources as the connectors/integration daemon are restarted over the lifetime of their hosting OMAG Server Platform.
-
-This pattern is not always possible if the integration connector needs to use a different interface to access the third party technology's metadata from its resources.  For example, the [Kafka Monitor Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/system-connectors/apache-kafka-connectors/README.md#kafka-monitor-integration-connector){ target=gh }, which detects the creation of new Kafka Topics and catalogues them in open metadata, does not use the [Kafka Open Metadata Topic Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/event-bus-connectors/open-metadata-topic-connectors/kafka-open-metadata-topic-connector/README.md){ target=gh } because it uses a different Apache Kafka interface to do its work.
+This pattern is not always possible if the integration connector needs to use a different interface to access the third party technology's metadata from its resources.  For example, the [Kafka Topic Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/system-connectors/apache-kafka-connectors/README.md){ target=gh }, which detects the creation of new Kafka Topics and catalogues them in open metadata, does not use the [Kafka Open Metadata Topic Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/event-bus-connectors/open-metadata-topic-connectors/kafka-open-metadata-topic-connector/README.md){ target=gh } because it uses a different Apache Kafka interface to do its work.
 
 ### Metadata flow for your connector
 
-The `refresh` method of your connector is called periodically to ensure the metadata in the third party technology is consistent with the metadata in the open metadata ecosystem.  It operates in two phases:
+The `refresh` method of your connector is called periodically to ensure the metadata in the third party technology is consistent with the metadata in the open metadata ecosystem.  When the connector supports catalog targets, `refresh()` is called on each catalog target processor in turn, and each pass operates in two phases:
 
 1. Retrieving metadata from the source and ensuring the equivalent metadata is present in the metadata destination.
 
@@ -72,19 +105,27 @@ The `refresh` method of your connector is called periodically to ensure the meta
 ![Third party technology is the metadata source](third-party-metadata-source.svg)
 > When the third party technology is the metadata source (for example, it is a relational database or a file system) the refresh method ensures that the open metadata in Egeria is exactly the same as the metadata in the third party technology.
 
-![Third party technology is the metadata destination](third-party-metadata-source.svg)
+![Third party technology is the metadata destination](third-party-metadata-destination.svg)
 > When the open metadata ecosystem is the metadata source and the integration connector is responsible for distributing a subset of the open metadata to the third party technology, the refresh method ensures this subset (and no more) is present in the third party technology.
+
+The direction of flow is controlled by the *permitted synchronization* setting.  It can be set on the connector as a whole and overridden for each catalog target, so a single connector instance can be pushing metadata to one resource while pulling it from another.  Test it with `getPermittedSynchronization()` before writing to either side.
+
+The [integration iterators](/guides/developer/integration-connectors/integration-context/#integration-iterators) supplied by the [Open Integration Framework (OIF)](/frameworks/oif/overview) implement the second phase for you: given the creation and update times of an element in the third party technology, a `MemberElement` will tell you whether the open metadata copy needs to be created, updated, deleted or left alone.
 
 ### Mapping the third party technology to open metadata
 
 Your integration connector needs to be able to map between the elements in the third party technology and in the open metadata ecosystem.  Each will use different unique identifiers that it is unlikely that you can control.  Design the `qualifiedName` of the open metadata elements to be constructable from the identifier of the equivalent metadata element in the third party technology.
 
 ??? tip "What if there is not a one-to-one correspondence between elements"
-    The integration context supports [external identifiers](/features/external-identifiers/overview) which can help to correlate complex relationships between the third party technology and open metadata.
-    
+    The integration context supports [external identifiers](/features/external-identifiers/overview) which can help to correlate complex relationships between the third party technology and open metadata.  Retrieve the client with `integrationContext.getExternalIdClient()`.
+
+Wherever the elements you create are standard - a database, a file, a topic - consider [templated cataloguing](/features/templated-cataloguing/overview) rather than building the elements property by property.  Templates are supplied on the connector's configuration properties and on each *CatalogTarget* relationship, and are retrieved with `getTemplates()`.
+
 ## Controlling external source metadata provenance
 
-The [configuration for an integration connector](/guides/admin/servers/by-server-type/configuring-an-integration-daemon) in the Integration Daemon includes a *metadataSourceQualifiedName*.  The default value is null which means store the metadata in any [metadata collection](/concepts/metadata-collection) that is owned by the locally connected cohorts.  Alternatively, it specifies the [qualifiedName](/concepts/referenceable) of a [software capability](/concepts/software-capability) entity that represents the third party technology.   This is automatically catalogued by the integration daemon if it is not found in the open metadata ecosystem.  The guid and qualifiedName of this entity is used to identify the [external metadata collection](/concepts/metadata-collection) that any open metadata elements created by the integration connector will be stored in.  This prevents processes other than the integration connector from modifying the metadata elements.
+The configuration for an integration connector includes a *metadataSourceQualifiedName*.  The default value is null which means store the metadata in any [metadata collection](/concepts/metadata-collection) that is owned by the locally connected cohorts.  Alternatively, it specifies the [qualifiedName](/concepts/referenceable) of a [software capability](/concepts/software-capability) entity that represents the third party technology.   This is automatically catalogued by the integration daemon if it is not found in the open metadata ecosystem.  The guid and qualifiedName of this entity is used to identify the [external metadata collection](/concepts/metadata-collection) that any open metadata elements created by the integration connector will be stored in.  This prevents processes other than the integration connector from modifying the metadata elements.
+
+Each *CatalogTarget* relationship can supply its own *metadataSourceQualifiedName*.  This means that the metadata gathered from each piece of third party technology is held in its own metadata collection, even though one connector instance created it all.
 
 ## Writing the connector provider
 
@@ -93,17 +134,16 @@ The [configuration for an integration connector](/guides/admin/servers/by-server
 ---8<-- "docs/guides/developer/integration-connectors/implementing-an-integration-connector-provider.md"
 
 
-!!! example "Example: connector provider for the Kafka Monitor Integration Connector"
-    For example, the [`KafkaMonitorIntegrationProvider` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/kafka-audit-integration-connector/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/kafkaaudit/DistributeAuditEventsFromKafkaProvider.java){ target=gh } is used to instantiate connectors that are monitoring an Apache Kafka broker. Therefore, its name and description refer to Kafka, and the connectors it instantiates are of type [`KafkaMonitorIntegrationConnector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/kafka-audit-integration-connector/src/main/java/org/odpi/openmetadata/adapters/connectors/integration/kafkaaudit/DistributeAuditEventsFromKafkaConnector.java){ target=gh }.
+!!! example "Example: connector provider for the PostgreSQL Server Integration Connector"
+    The [`PostgresServerIntegrationProvider` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/postgres/catalog/PostgresServerIntegrationProvider.java){ target=gh } is used to instantiate connectors that catalog the databases in a PostgreSQL database server.  Its catalog target types show that it accepts either a PostgreSQL server or an individual PostgreSQL database, and the connectors it instantiates are of type [`PostgresServerIntegrationConnector` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/data-manager-connectors/postgres-server-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/postgres/catalog/PostgresServerIntegrationConnector.java){ target=gh }.
 
 ## Writing the connector
 
-The connector extends the [appropriate integration connector interface](#integration-connector-interface) and has a default constructor:
+The connector extends [`DynamicIntegrationConnectorBase`](#choosing-a-base-class) and has a default constructor:
 
 ```java
-public class MyIntegrationConnector extends FilesIntegratorConnector
+public class MyIntegrationConnector extends DynamicIntegrationConnectorBase
 {
-
     /**
      * Default constructor used by the connector provider.
      */
@@ -112,44 +152,62 @@ public class MyIntegrationConnector extends FilesIntegratorConnector
         super();
     }
 
+    /**
+     * Create a new catalog target processor for each catalog target attached to this connector.
+     */
+    @Override
+    public RequestedCatalogTarget getNewRequestedCatalogTargetSkeleton(CatalogTarget        retrievedCatalogTarget,
+                                                                       CatalogTargetContext catalogTargetContext,
+                                                                       Connector            connectorToTarget)
+    {
+        return new MyCatalogTargetProcessor(retrievedCatalogTarget,
+                                            catalogTargetContext,
+                                            connectorToTarget,
+                                            connectorName,
+                                            auditLog);
+    }
 }
-
-
 ```
+
+Most of the logic then lives in `MyCatalogTargetProcessor` - see [supporting catalog targets](/guides/developer/integration-connectors/catalog-targets).
 
 ### Accessing configuration properties and the endpoint
 
-The connection object is stored in the `connectionProperties` instance variable defined by the super class.  It is typically accessed in the `start()` method. The code snippet below accesses the endpoint and configuration properties from the connection.  It also uses the audit log to record a start-up message
+The connection object is stored in the `connectionBean` instance variable defined by the super class.  It is typically accessed in the `start()` method.  The base class supplies typed accessors for the configuration properties, so your code does not have to deal with casting and null checks:
 
 ```java
     /**
      * Indicates that the connector is completely configured and can begin processing.
-     * This call can be used to register with non-blocking services.
      *
      * @throws ConnectorCheckedException there is a problem within the connector.
+     * @throws UserNotAuthorizedException the connector was disconnected before/during start
      */
     @Override
-    public void start() throws ConnectorCheckedException
+    public void start() throws ConnectorCheckedException, UserNotAuthorizedException
     {
         super.start();
 
         final String methodName = "start";
 
         /*
-         * Extract the configuration
+         * Extract the configuration.  These values act as defaults for all of the catalog targets;
+         * each catalog target can override them on its CatalogTarget relationship.
          */
-        EndpointProperties  endpoint = connectionProperties.getEndpoint();
+        Map<String, Object> configurationProperties = connectionBean.getConfigurationProperties();
+
+        excludeList = super.getArrayConfigurationProperty(MyConfigurationProperty.EXCLUDE_LIST.getName(),
+                                                          configurationProperties);
+        batchSize   = super.getIntConfigurationProperty(MyConfigurationProperty.BATCH_SIZE.getName(),
+                                                        configurationProperties);
+
+        /*
+         * If this connector uses an explicit endpoint rather than catalog targets, it is on the connection.
+         */
+        Endpoint endpoint = connectionBean.getEndpoint();
 
         if (endpoint != null)
         {
-            myEndpoint = endpoint.getAddress();
-        }
-
-        Map<String, Object> configurationProperties = connectionProperties.getConfigurationProperties();
-
-        if (configurationProperties != null)
-        {
-            :
+            myNetworkAddress = endpoint.getNetworkAddress();
         }
 
         /*
@@ -158,51 +216,37 @@ The connection object is stored in the `connectionProperties` instance variable 
         if (auditLog != null)
         {
             auditLog.logMessage(methodName,
-                                MyConnectorsAuditCode.CONNECTOR_CONFIGURATION.getMessageDefinition(connectorName,myEndpoint));
+                                MyConnectorsAuditCode.CONNECTOR_CONFIGURATION.getMessageDefinition(connectorName, myNetworkAddress));
         }
-
-        :
     }
-
-
 ```
 
 ### Accessing context
 
-The context is retrieved using the `getIntegrationContext()` method.   This is a synchronized method that can be called from multiple threads, that occurs when the connector is using listeners.
+The [integration context](/guides/developer/integration-connectors/integration-context) is available through the `integrationContext` variable set up by the base class.  Each catalog target processor has its own `CatalogTargetContext` - also called `integrationContext` - that is already scoped to that target's metadata source and permitted synchronization.
 
 ### Registering a listener with open metadata
 
-An integration connector that is listening for events from the open metadata ecosystem should implement the listener interface [OpenMetadataEventListener](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataEventListener.html).  This interface has a `processEvent()` method that your connector implements.  
+An integration connector that is listening for events from the open metadata ecosystem implements the listener interface [OpenMetadataEventListener](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataEventListener.html).  This interface has a `processEvent()` method that takes an [OpenMetadataOutTopicEvent](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataOutTopicEvent.html).
 
-Your integration connector registers itself as a listener in the `start()` method, and the `processEvent()` method is called each time an event occurs.   The event type passed on `processEvent()` is a [OpenMetadataOutTopicEvent](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataOutTopicEvent.html).
+If your connector extends `DynamicIntegrationConnectorBase`, simply declaring that it implements `OpenMetadataEventListener` is enough.  The base class registers the listener at the end of the first `refresh()`, implements `processEvent()`, and passes each event on to any catalog target processor that also implements `OpenMetadataEventListener`.  Delaying the registration until the first refresh has completed reduces the flood of events caused by the connector's own initial synchronization.
+
+If you are registering the listener yourself, do it in the `start()` method:
 
 ```java
-    /**
-     * Indicates that the connector is completely configured and can begin processing.
-     *
-     * @throws ConnectorCheckedException there is a problem within the connector.
-     */
     @Override
-    public synchronized void start() throws ConnectorCheckedException
+    public synchronized void start() throws ConnectorCheckedException, UserNotAuthorizedException
     {
         super.start();
 
-        :
-        :
-                                
-        myContext = super.getIntegrationContext();
-
-        if (myContext != null)
+        if (integrationContext.noListenerRegistered())
         {
-                myContext.registerListener(this);
+            integrationContext.registerListener(this);
         }
     }
 
      /**
-      * Process an event that was published by the Open Metadata Service.  This connector is only interested in
-      * glossaries, glossary categories, and glossary terms.   The listener is only registered if metadata is flowing
-      * from the open metadata ecosystem to Apache Atlas.
+      * Process an event that was published by the open metadata ecosystem.
       *
       * @param event event object
       */
@@ -213,128 +257,44 @@ Your integration connector registers itself as a listener in the `start()` metho
          * Only process events if refresh() is not running because the refresh() process creates lots of events and
          * proceeding with event processing at this time causes elements to be processed multiple times.
          */
-        if (! myContext.isRefreshInProgress())
+        if (integrationContext.noRefreshInProgress())
         {
-        ...
+            :
         }
      }
-
 ```
-The `isRefreshInProgress()` call is used to ensure this connector ignores events while its `refresh()` is being called.  For many connectors, many of the events created during this time are caused by the connector's own activity.  Therefore, ignoring events at this time can avoid processing elements multiple times.
 
-### Working with the third party technology
+The `noRefreshInProgress()` call is used to ensure this connector ignores events while its `refresh()` is being called.  For many connectors, many of the events created during this time are caused by the connector's own activity.  Therefore, ignoring events at this time can avoid processing elements multiple times.
 
-Ideally your integration connector should use an embedded [digital resource connector](/concepts/digital-resource-connector).  This is configured as an *embedded connection* in the VirtualConnection used to configure the integration connector.  When the integration connector is initialized, the embedded connections are used to create the embedded connectors.  They can be accessed via the *embeddedConnectors* variable.  As an example, here is the `start()` method from the [OpenLineage Event Receiver Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/openlineage-integration-connectors/README.md#open-lineage-event-receiver-integration-connector){ target=gh } which uses an embedded [Open Metadata Topic Connector](/concepts/open-metadata-topic-connector) to access an event source:
+### Listening for events from the third party technology
+
+The [OpenLineage Event Receiver Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/openlineage-integration-connectors/README.md#open-lineage-event-receiver-integration-connector){ target=gh } shows how to receive events from an event broker such as [Apache Kafka](https://kafka.apache.org/).  Each of its catalog targets is a topic, and the resource connector created for the target is an [Open Metadata Topic Connector](/concepts/open-metadata-topic-connector).  Its catalog target processor implements [OpenMetadataTopicListener](https://odpi.github.io/egeria/org/odpi/openmetadata/repositoryservices/connectors/openmetadatatopic/OpenMetadataTopicListener.html) and registers itself with the topic connector:
 
 ```java
-
-    private final Map<String, OpenMetadataTopicConnector> topicConnectors = new HashMap<>();
-
-    /**
-     * Indicates that the connector is completely configured and can begin processing.
-     * This call can be used to register with non-blocking services.
-     *
-     * @throws ConnectorCheckedException there is a problem within the connector.
-     */
-    @Override
-    public void start() throws ConnectorCheckedException
-    {
-        super.start();
-
-        final String methodName = "start";
-
-        myContext = super.getIntegrationContext();
-
-        if (myContext != null)
+        if (super.getConnectorToTarget() instanceof OpenMetadataTopicConnector topicConnector)
         {
-            if (embeddedConnectors != null)
+            topicConnector.registerListener(listener);
+
+            if (! topicConnector.isActive())
             {
-                for (Connector embeddedConnector : embeddedConnectors)
-                {
-                    if (embeddedConnector instanceof OpenMetadataTopicConnector)
-                    {
-                        /*
-                         * Register this connector as a listener of the event bus connector.
-                         */
-                        OpenMetadataTopicConnector topicConnector = (OpenMetadataTopicConnector)embeddedConnector;
-                        topicConnector.registerListener(this);
-
-                        ConnectionProperties connectionProperties = topicConnector.getConnection();
-
-                        if (connectionProperties != null)
-                        {
-                            EndpointProperties endpoint = connectionProperties.getEndpoint();
-
-                            if (endpoint != null)
-                            {
-                                topicConnectors.put(endpoint.getAddress(), topicConnector);
-                            }
-                        }
-                    }
-                }
-            }
-
-            for (String topicName : topicConnectors.keySet())
-            {
-                OpenMetadataTopicConnector topicConnector = topicConnectors.get(topicName);
-                ConnectionProperties       topicConnection = topicConnector.getConnection();
-
-                /*
-                 * Record the configuration
-                 */
-                if (auditLog != null)
-                {
-                    auditLog.logMessage(methodName,
-                                        OpenLineageIntegrationConnectorAuditCode.KAFKA_RECEIVER_CONFIGURATION.getMessageDefinition(connectorName,
-                                                                                                                                   topicName,
-                                                                                                                                   topicConnection.getConnectionName()));
-                }
-
                 topicConnector.start();
             }
         }
-    }
-
-
 ```
-Notice that *embeddedConnectors* is a list, since multiple connectors can be embedded.  The integration connector ignores any embedded connectors that are not *OpenMetadataTopicConnectors*.
 
-The [OpenLineage Event Receiver Integration Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/openlineage-integration-connectors/README.md#open-lineage-event-receiver-integration-connector){ target=gh } also demonstrates how the register a listener with an [Open Metadata Topic Connector](/concepts/open-metadata-topic-connector) to receive events from an event broker such as [Apache Kafka](https://kafka.apache.org/).
-
-The integration connector implements [OpenMetadataTopicListener](https://odpi.github.io/egeria/org/odpi/openmetadata/repositoryservices/connectors/openmetadatatopic/OpenMetadataTopicListener.html).
-
-```java
-public class OpenLineageEventReceiverIntegrationConnector extends LineageIntegratorConnector implements OpenMetadataTopicListener
-{
-    :
-
-    /**
-     * Method to pass an event received on topic.
-     *
-     * @param event inbound event
-     */
-    public void processEvent(String event)
-    {
-        :
-    }
-}
-```
-It then retrieves the embedded Open Metadata Topic Connector from the `embeddedConnectors` and calls `registerListener(this)` followed by  in its `start()` method.
-
-```java
-     topicConnector.registerListener(this);
-     :
-     topicConnector.start();
-```
-Once `topicConnector.start()` is called, the integration connector will receive events from Apache Kafka.
+Once `topicConnector.start()` is called, the connector will receive events from Apache Kafka.  Adding a new topic to listen on is then just a matter of attaching another catalog target.
 
 !!! attention "Do not create threads in your integration connector"
     Each integration connector runs in its own thread. Integration connectors should not create additional threads because this makes it difficult for Egeria to properly shut down the integration daemon independently of the OMAG Server Platform.
-    If the connector needs to make blocking calls to the third party technology, it should implement the `engage()` method and set the `usesBlockingCalls` property in the integration daemon configuration to `true`. When the `engage()` method is called on the thread, it should issue one blocking call and return.  The integration daemon will check that it is not in shutdown and if it is still running, it calls `engage()` again.
+    If the connector needs to make blocking calls to the third party technology, it should implement the `engage()` method and set the `usesBlockingCalls` property in its configuration to `true`. When the `engage()` method is called on the thread, it should issue one blocking call and return.  The integration daemon will check that it is not in shutdown and if it is still running, it calls `engage()` again.
 
 ### Exceptions and error handling
 
 The methods of the integration connector are able to throw `ConnectorCheckedException` to indicate there is a problem.  If your integration connector throws such an exception, the integration daemon switches it to `FAILED` status, and it is not called again until either the connector is restarted by the operator or the integration daemon is restarted.  Therefore, when your integration connector discovers a problem, it can either just return from the method in the hope the problem is resolved by the next time it is called, or it can throw an exception.  In either case it should [log an audit log message](#audit-log-messages).  If the error needs an operator action to resolve it, throwing a `ConnectorCheckedException` exception means that the integration connector is not needlessly taking up resources when it can not operate.  This is important if multiple failures are occurring and the ecosystem is under stress.  However, throwing an exception for a temporary error that will resolve itself takes the integration connector offline unnecessarily and creates work for the operators.
+
+Catalog targets change this balance.  The framework calls each catalog target processor inside its own try/catch and logs any exception, so a problem with one target only takes that target out of action for that pass - the other targets carry on.  This means a catalog target processor can afford to be stricter about reporting problems than a connector that has to keep the whole show on the road.
+
+A `UserNotAuthorizedException` from the context means that the connector has been disconnected.  Let it propagate rather than catching it, so that processing stops promptly.
 
 The integration connector should only catch exceptions that inherit from `java.lang.Exception` since runtime exceptions are something that need to be handled by the broader runtime environment.
 
@@ -347,6 +307,8 @@ Audit log messages help the people operating Egeria to be sure your integration 
 * At the end of the `disconnect()` method to confirm it has shutdown.
 * If the integration connector detects an error.  This message should include the error information from the third party technology to aid diagnosis of the problem.
 
+Where the connector supports catalog targets, include the `getCatalogTargetName()` value in the message so that operators can tell which target a message relates to.  The framework already logs a message as each catalog target is refreshed, and a summary of how many were processed.
+
 ## Testing your connector
 
 Your integration connector implementation should be built and packaged in a *jar* file.  This jar file contains your connector provider and connector implementation.  It may optionally contain any dependent client libraries to the third party connector that are called directly by your integration connector.  This is necessary if these client libraries are not available in their own jar file.
@@ -357,15 +319,22 @@ Once you have installed the connector, configure it in the integration daemon, c
 
 ![Figure 6](testing.svg)
 
-Your connector is then able to start and exchange metadata.
+Then catalog the technology you want it to work with, and attach the resulting asset to your connector as a catalog target.  Your connector is then able to start and exchange metadata.
 
 ![Figure 7](/services/integration-daemon-internals.svg)
+
+Testing a connector that supports catalog targets is easier than the older style: you can add and remove targets while the connector runs, and use the integration daemon's refresh REST API call to trigger a pass on demand rather than waiting for the refresh interval.
 
 ## Documenting your connector
 
 All connectors should be documented in some form of connector catalog to ensure they are easy for others to reuse.  If your connector is either part of Egeria, or available from a public download, you may advertise it in Egeria's [connector catalog](/connectors).
 
+Describing your connector in an [open metadata archive](/concepts/open-metadata-archive) means it can be loaded into a metadata access store at start up, along with the templates and reference data it needs.  See [creating content packs](/guides/developer/open-metadata-archives/creating-content-packs).
+
 ??? education "Further information"
+    - [Supporting catalog targets](/guides/developer/integration-connectors/catalog-targets) - the recommended structure for a new connector.
+    - [The integration context](/guides/developer/integration-connectors/integration-context) - what the connector can do with open metadata.
+    - [Self-registering integration connectors](/guides/developer/integration-connectors/self-registering-integration-connectors) - connectors that find their own catalog targets.
     - [Open Connector Framework (OCF)](/frameworks/ocf/overview) that defines the behavior of all connectors.
     - [Configuring an integration daemon](/guides/admin/servers/by-server-type/configuring-an-integration-daemon) to understand how to set up an integration connector.
     - [Developer guide](/guides/developer) for more information on writing connectors.

--- a/site/docs/guides/developer/integration-connectors/integration-connector-interface.md
+++ b/site/docs/guides/developer/integration-connectors/integration-connector-interface.md
@@ -4,46 +4,50 @@
 
 An integration connector can:
 
-- Listen on a blocking call, waiting for the third party technology to send a notification.
+- Poll the third party technology each time that the integration daemon calls your integration connector's `refresh()` method.
+- Register a listener with its context to act on notifications from the open metadata ecosystem.
 - Register with an external notification service that sends notifications on its own thread.
-- Register a listener with its context to act on notifications from the partner OMAS's [Out Topic](/concepts/out-topic).
-- Poll the third party technology each time that the integration daemon calls your integration connector's  `refresh()` method.
+- Listen on a blocking call, waiting for the third party technology to send a notification.
 - Issue queries and maintenance (create, update, delete) requests to the open metadata repositories.
 
-Access to open metadata is provided via a *context* object defined by the [Open Integration Framework (OIF)](/frameworks/oif/overview).  This includes:
+Access to open metadata is provided via a *context* object defined by the [Open Integration Framework (OIF)](/frameworks/oif/overview).  There is a [single context interface](/guides/developer/integration-connectors/integration-context) for all integration connectors; it provides:
 
-- The ability to register a listener to receive events from the OMAS's [Out Topic](/concepts/out-topic).
-- The ability to create and update metadata instances.
-- For assets, the ability to change an asset's visibility by changing its zone membership using the `publish` and `withdraw` methods.
-- The ability to delete metadata.
-- Various retrieval methods to help when comparing the metadata in the open metadata repositories with the metadata in the third party technology.
+- The ability to register a listener to receive events from the open metadata ecosystem.
+- A [client for each type of open metadata element](/guides/developer/integration-connectors/integration-context/#the-open-metadata-clients) that can create, update, classify, link and delete metadata, along with the retrieval methods needed to compare open metadata with the metadata in the third party technology.
+- The ability to create a [digital resource connector](/concepts/digital-resource-connector) for an asset so that the third party technology can be called.
+- Support for [external identifiers](/features/external-identifiers/overview), [templates](/features/templated-cataloguing/overview) and [external source metadata provenance](/features/metadata-provenance/overview).
+- Utilities such as the file classifier, the directory listeners and the name case converters.
 
-The context object is a wrapper around the client of an [Open Metadata Access Service (OMAS)](/services/omas).  It is accessed by the integration connector using the `getContext()` method.  The OMAS supplies the properties, open metadata listener interface and event structures for the API.
+!!! attention "The integration services have been removed"
+    Earlier releases of Egeria offered a range of *Open Metadata Integration Services (OMISs)*, each with its own specialized context interface and its own set of base classes (`DatabaseIntegratorConnector`, `FilesIntegratorConnector`, `TopicIntegratorConnector` and so on).  Choosing the right integration service was the first decision a connector developer had to make.
+    
+    These services have been removed.  All function is now available through the single [integration context](/guides/developer/integration-connectors/integration-context) supplied by the Open Integration Framework, and there are just two base classes to choose between (described below).  If you are migrating an older connector, the mapping is mostly mechanical: replace the `XXXIntegratorConnector` superclass with `DynamicIntegrationConnectorBase`, and replace the `getContext()` calls with the `integrationContext` variable.
 
-These dependencies are in addition to the standard dependencies for an integration connector:
+## Dependencies
 
-* [Audit log framework](/frameworks/alf/overview) - for logging audit log messages.
-* [Open Connector Framework](/frameworks/ocf/overview) - basic connector interfaces.
-* [Integration Daemon API](/services/integration-daemon-services) - for the integration connector base classes.
-* [Repository Services APIs](/services/omrs) - for audit log message severities.
+These are the standard dependencies for an integration connector:
+
+* [Audit log framework (ALF)](/frameworks/alf/overview) - for logging audit log messages.
+* [Open Connector Framework (OCF)](/frameworks/ocf/overview) - basic connector interfaces.
+* [Open Metadata Framework (OMF)](/frameworks/omf/overview) - the open metadata clients, properties and types used by the context.
+* [Open Integration Framework (OIF)](/frameworks/oif/overview) - the integration connector base classes and the integration context.
+* [Open Governance Framework (OGF)](/frameworks/ogf/overview) - the catalog target properties and the ability to initiate governance actions.
+
+??? example "Example of the Gradle dependencies for an integration connector ..."
+
+    ```groovy
+    dependencies {
+        compileOnly 'org.odpi.egeria:audit-log-framework'
+        compileOnly 'org.odpi.egeria:open-connector-framework'
+        compileOnly 'org.odpi.egeria:open-metadata-framework'
+        compileOnly 'org.odpi.egeria:open-integration-framework'
+        compileOnly 'org.odpi.egeria:open-governance-framework'
+    }
+    ```
 
 ??? example "Example of the Maven dependencies for an integration connector ..."
     
     ```xml
-            <dependency>
-                <groupId>org.odpi.egeria</groupId>
-                <artifactId>topic-integrator-api</artifactId>
-                <scope>provided</scope>
-                <version>${open-metadata.version}</version>
-            </dependency>
-    
-            <dependency>
-                <groupId>org.odpi.egeria</groupId>
-                <artifactId>data-manager-api</artifactId>
-                <scope>provided</scope>
-                <version>${open-metadata.version}</version>
-            </dependency>
-        
             <dependency>
                 <groupId>org.odpi.egeria</groupId>
                 <artifactId>audit-log-framework</artifactId>
@@ -57,54 +61,80 @@ These dependencies are in addition to the standard dependencies for an integrati
                 <scope>provided</scope>
                 <version>${open-metadata.version}</version>
             </dependency>
-    
+
             <dependency>
                 <groupId>org.odpi.egeria</groupId>
-                <artifactId>repository-services-apis</artifactId>
+                <artifactId>open-metadata-framework</artifactId>
                 <scope>provided</scope>
                 <version>${open-metadata.version}</version>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.odpi.egeria</groupId>
-                <artifactId>integration-daemon-services-api</artifactId>
+                <artifactId>open-integration-framework</artifactId>
                 <scope>provided</scope>
                 <version>${open-metadata.version}</version>
             </dependency>
-    
+
+            <dependency>
+                <groupId>org.odpi.egeria</groupId>
+                <artifactId>open-governance-framework</artifactId>
+                <scope>provided</scope>
+                <version>${open-metadata.version}</version>
+            </dependency>
     ```
     
     !!! tip "Use provided scope ..."
 
-        Notice the `<scope>provided</scope>` setting for the Egeria libraries.  This prevents the Egeria libraries from being included in your connector jar file.  By using the provided scope, your connector can run with any level of Egeria that supports this type of connector.  Without it, duplicate Egeria classes would be loaded into your OMAG Server Platform and if the platform was running at a different level it is not certain which version of the classes would run. (It "may" be ok but experience, as we know, teaches us that "if it can go wrong it will go wrong" so avoiding problems is always preferable :).   
+        Notice the `<scope>provided</scope>` setting for the Egeria libraries (`compileOnly` in Gradle).  This prevents the Egeria libraries from being included in your connector jar file.  By using the provided scope, your connector can run with any level of Egeria that supports this type of connector.  Without it, duplicate Egeria classes would be loaded into your OMAG Server Platform and if the platform was running at a different level it is not certain which version of the classes would run. (It "may" be ok but experience, as we know, teaches us that "if it can go wrong it will go wrong" so avoiding problems is always preferable :).
 
 You will also need to add the dependencies for the third party technology that your connector is calling.
 
-All the integration connector base classes inherit from (extend) the [`IntegrationConnectorBase` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/IntegrationConnectorBase.java){ target=gh }.  This class defines the lifecycle methods of the integration connector.
+## Choosing a base class
+
+All integration connectors inherit from (extend) the [`IntegrationConnectorBase` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/IntegrationConnectorBase.java){ target=gh }.  This class defines the lifecycle methods of the integration connector.  There are two ways to build on it:
+
+=== "DynamicIntegrationConnectorBase (recommended)"
+
+    [`DynamicIntegrationConnectorBase` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/connectors/DynamicIntegrationConnectorBase.java){ target=gh } extends `IntegrationConnectorBase` to add support for [catalog targets](/concepts/catalog-target).
+
+    A single running instance of the connector works with many pieces of third party technology.  Each one is attached to the connector's metadata element using a *CatalogTarget* relationship, and the work for it is performed by a [catalog target processor](/guides/developer/integration-connectors/catalog-targets).  The base class discovers the catalog targets, creates and starts a processor for each one, calls `refresh()` on each of them, distributes open metadata events to them, and disconnects the ones that are removed.
+
+    This is the right choice for almost every new connector.  See [supporting catalog targets](/guides/developer/integration-connectors/catalog-targets).
+
+=== "IntegrationConnectorBase"
+
+    Extending `IntegrationConnectorBase` directly means your connector works with exactly one piece of third party technology, identified by the [endpoint](/concepts/endpoint) in its own [connection](/concepts/connection).  To monitor three databases you would deploy three configured instances of the connector.
+
+    Use this style only when the connector is not working with a catalogued resource at all - for example, the [OpenLineage log store connectors :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/integration-connectors/openlineage-integration-connectors/README.md){ target=gh } that write a log of open lineage events to a fixed destination.
+
+## The lifecycle methods
 
 ![Methods implemented by an integration connector](/guides/developer/integration-connectors/integration-connector-methods.svg)
-> Methods implemented by an integration connector.  The base class implements the initialize(), setAuditLog(), setConnectorName(), and setContext() methods.  Your integration connector only needs to supply the start, refresh and disconnect method.  It implements the engage method only if it needs to issue a blocking call.
+> Methods implemented by an integration connector.  The base class implements the `initialize()`, `setAuditLog()`, `setConnectorName()`, `initializeEmbeddedConnectors()` and `setContext()` methods.  Your integration connector supplies the `start()`, `refresh()` and `disconnect()` methods.  It implements the `engage()` method only if it needs to issue a blocking call.  When the connector supports catalog targets, the `start()`, `refresh()` and `disconnect()` methods are also implemented on each target processor - one for each catalog target.
 
-- `initialize` is a standard method for all connectors that is called by the [connector broker](/concepts/connector-broker) when a request is made to create an instance of the connector. The connector broker uses the initialize method to pass the [connection](/concepts/connection) object used to create the connector instance and a unique identifier for this instance of the connector. This method is provided by the integration connector's base class.  Your code can access the connection properties via the `connectionProperties` variable and the connector's unique identifier via the `connectorInstanceId` variable.
+- `initialize` is a standard method for all connectors that is called by the [connector broker](/concepts/connector-broker) when a request is made to create an instance of the connector. The connector broker uses the initialize method to pass the [connection](/concepts/connection) object used to create the connector instance and a unique identifier for this instance of the connector. This method is provided by the integration connector's base class.  Your code can access the connection via the `connectionBean` variable and the connector's unique identifier via the `connectorInstanceId` variable.
 
 - `setAuditLog` provides an [Audit Log Framework (ALF)](/frameworks/alf/overview) compatible logging destination. This method is provided by the integration connector's base class.  Your code can access the audit log via the `auditLog` variable.
 
 - `setConnectorName` provides the name of the connector from the configuration, so it can be used for logging. This method is provided by the integration connector's base class.  Your code can access your integration connector's name via the `connectorName` variable.
 
-- `initializeEmbeddedConnectors` saves the optional list of embedded connectors that were defined in the connection object for your integration connector when it was configured.  These connectors are [digital resource connectors](/concepts/digital-resource-connector) for use by your integration connector to [call the third party technology](/guides/developer/integration-connectors/#designing-your-integration-connector). This method is provided by the integration connector's base class.  Your code can access the embedded connector's via the `embeddedConnectors` variable.
+- `initializeEmbeddedConnectors` saves the optional list of embedded connectors that were defined in the connection object for your integration connector when it was configured.  These connectors are [digital resource connectors](/concepts/digital-resource-connector) - a secrets store connector is a common example. This method is provided by the integration connector's base class.  Your code can access the embedded connectors via the `embeddedConnectors` variable.
 
-- `setContext` sets up the context object. Your code can access the connector's name via the `context` variable.  However, it is recommended that because it is set to null after the `disconnect` method (described below), your connector should use the `super.getContext()` method to access the context, particularly if your connector operates in multiple threads, which occurs when the connector is using listeners.
+- `setContext` sets up the [integration context](/guides/developer/integration-connectors/integration-context) object. This method is provided by the integration connector's base class.  Your code accesses the context through the `integrationContext` variable.  Note that when the connector supports catalog targets, each catalog target processor has its own specialized `CatalogTargetContext`, also called `integrationContext`, which is set up for the metadata source and permitted synchronization of its particular catalog target.
     
-- `start` indicates that the connector is completely configured (that is all the methods listed above have been called) and it can begin processing. This call is where the configuration properties are extracted from the connection object. It can also be used to register with non-blocking services. For example, it can register a listener for events from the OMAS [Out Topic](/concepts/out-topic) through the context.
+- `start` indicates that the connector is completely configured (that is all the methods listed above have been called) and it can begin processing. This call is where the configuration properties are extracted from the connection object.  It is also where the catalog targets manager is created, so always call `super.start()` first.
 
-- `engage` is used as an alternative to `refresh` when the connector is configured to need to issue blocking calls to wait for new metadata. It is called from its own thread. It is recommended that the `engage()` method returns when each blocking call completes. The integration daemon will pause a second and then call `engage()` again. This pattern enables the calling thread to detect the shutdown of its hosting integration daemon server.  This method is implemented by the integration connector's base class to do nothing.  You only need to override it if your integration connector is issuing blocking calls. 
+- `engage` is used as an alternative to `refresh` when the connector is configured to need to issue blocking calls to wait for new metadata. It is called from its own thread. It is recommended that the `engage()` method returns when each blocking call completes. The integration daemon will pause a second and then call `engage()` again. This pattern enables the calling thread to detect the shutdown of its hosting integration daemon server.  The base class implementation throws an exception because a call to it indicates a mismatch between the configuration and the connector implementation.  You only need to override it if your integration connector is issuing blocking calls.
 
 - `refresh` requests that the connector does a comparison of the metadata in the third party technology and open metadata repositories. Refresh is called from the connector's own thread under the following conditions:
 
     1. when the integration connector first starts and then
     1. at intervals defined in the connector's configuration as well as
     1. any external REST API calls to explicitly refresh the connector.
-    
-- `disconnect` is called when the server is shutting down. The connector should free up any resources that it holds since it is not needed any more.  Once disconnect has been called the context is no longer valid.
 
-Therefore, you are typically looking to implement the `start`, `refresh` and `disconnect` methods in your integration connector, and optionally overriding the `engage` method if your connector issues blocking calls.
+    `DynamicIntegrationConnectorBase` implements `refresh()` for you: it re-reads the catalog targets and calls `refresh()` on each catalog target processor.  If you override it, call `super.refresh()`.
+    
+- `disconnect` is called when the server is shutting down. The connector should free up any resources that it holds since it is not needed any more.  The base class disconnects the catalog targets' resource connectors, so call `super.disconnect()`.  Once disconnect has been called the context is no longer valid; calls to it throw `UserNotAuthorizedException`.
+
+Therefore, you are typically looking to implement the `start`, `refresh` and `disconnect` methods in your integration connector, and optionally overriding the `engage` method if your connector issues blocking calls.  If your connector supports catalog targets, most of this work moves to the [catalog target processor](/guides/developer/integration-connectors/catalog-targets), and the connector class itself becomes very small.

--- a/site/docs/guides/developer/integration-connectors/integration-context.md
+++ b/site/docs/guides/developer/integration-connectors/integration-context.md
@@ -1,0 +1,180 @@
+<!-- SPDX-License-Identifier: CC-BY-4.0 -->
+<!-- Copyright Contributors to the Egeria project. -->
+
+# The integration context
+
+The *integration context* is the integration connector's gateway into the open metadata ecosystem.  It is created by the [integration daemon](/concepts/integration-daemon) and passed to the connector through the `setContext()` method before `start()` is called.  Your code accesses it through the `integrationContext` variable.
+
+```java
+    integrationContext.getAssetClient(OpenMetadataType.TOPIC.typeName);
+```
+
+!!! attention "The context replaces the integration services"
+    Earlier releases supplied a different context for each *Open Metadata Integration Service (OMIS)*, and the connector developer had to choose the service - and therefore the context interface - that best matched the technology they were integrating.  A connector that catalogued both files and databases had a problem.
+    
+    There is now a single context, defined by the [Open Integration Framework (OIF)](/frameworks/oif/overview), and every function is available to every connector.  There is no `getContext()` method; use the `integrationContext` variable directly.
+
+## The class hierarchy
+
+```mermaid
+flowchart TD
+    A["`**ConnectorContextBase**
+    _(OMF)_
+    the open metadata clients, activity reports, file utilities`"] --> B["`**IntegrationContext**
+    _(OIF)_
+    permitted synchronization, event listeners, refresh state, open lineage`"]
+    B --> C["`**CatalogTargetContext**
+    _(OIF)_
+    scoped to a single catalog target`"]
+```
+
+`ConnectorContextBase` is shared with the [survey action services](/guides/developer/survey-action-services/overview) and [governance action services](/guides/developer/governance-action-services/overview), so the way you work with open metadata is the same wherever your code runs.
+
+Each [catalog target](/concepts/catalog-target) processor is given its own `CatalogTargetContext`.  It behaves identically, but it is pre-configured with the metadata source (external metadata collection) and permitted synchronization of its particular target, so metadata created through it is automatically attributed to the right place.
+
+## The open metadata clients
+
+The context supplies a client for each category of open metadata element.  Each client is retrieved with a `getXXXClient()` method:
+
+```java
+        AssetClient              assetClient              = integrationContext.getAssetClient(OpenMetadataType.TOPIC.typeName);
+        SoftwareCapabilityClient softwareCapabilityClient = integrationContext.getSoftwareCapabilityClient(OpenMetadataType.EVENT_BROKER.typeName);
+        CollectionClient         collectionClient         = integrationContext.getCollectionClient(OpenMetadataType.DATA_HUB.typeName);
+        GlossaryTermClient       glossaryTermClient       = integrationContext.getGlossaryTermClient();
+```
+
+Most `getXXXClient()` methods have an overload that takes an open metadata type name.  Passing the specific type - for example `Topic` rather than the default `Asset` - means that new elements are created with that type and queries are restricted to it.
+
+There are clients for assets, software capabilities, collections, connections, connector types, endpoints, schema types, schema attributes, data fields, data structures, glossary terms, governance definitions, information supply chains, lineage, locations, projects, communities, actor profiles, actor roles, user identities, external references, external identifiers, valid values, annotations, note logs, comments, ratings, likes, informal tags, search keywords, context events, design patterns, perspectives, solution components, property facets and more.  The [`ConnectorContextBase` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-metadata-framework/src/main/java/org/odpi/openmetadata/frameworks/openmetadata/connectorcontext/ConnectorContextBase.java){ target=gh } javadoc lists them all.
+
+Two general purpose clients complete the set:
+
+* `getOpenMetadataStore()` returns the generic [`OpenMetadataStore`](/frameworks/omf/overview) for working with elements of any type through the generic properties interface.
+* `getClassificationExplorerClient()` finds elements by their classifications - for example, all the elements in a given metadata collection.
+
+### Options objects
+
+Every client method takes an *options* object that carries the qualifiers for the request - paging, effective time, as-of time, governance zone filters, sequencing order, whether the request is for lineage or duplicate processing, and the metadata source to attribute the change to.  Each client can build a correctly defaulted options object for you:
+
+| Method | Used for |
+|---|---|
+| `getGetOptions()` | retrieving a single element by GUID |
+| `getQueryOptions(startFrom, pageSize)` | retrieving lists of elements |
+| `getSearchOptions(startFrom, pageSize)` | `find...` methods that take a search string |
+| `getMetadataSourceOptions()` | creating elements with the correct external provenance |
+| `getMakeAnchorOptions(makeAnchor)` | attaching a new element to an anchor |
+| `getUpdateOptions(mergeUpdate)` | updating an element |
+| `getDeleteOptions(cascadedDelete)` | deleting an element |
+
+Defaults that apply to every request from a client can be set once - `setForLineage()`, `setForDuplicateProcessing()`, `setEffectiveTimeDefault()`, `setAsOfTimeDefault()`, `setGovernanceZonesFilterDefault()`, `setSequencingOrderDefault()` and `setLimitResultsByStatusDefault()`.
+
+### Controlling visibility
+
+`publishElement()` and `withdrawElement()` change an asset's [governance zone](/features/governance-zoning/overview) membership so that it becomes visible, or is hidden from, the consumers of the catalog.  This lets a connector catalog an asset fully before making it visible.
+
+## Working with the third party technology
+
+`getConnectedAssetContext().getConnectorForAsset(assetGUID, auditLog)` creates a [digital resource connector](/concepts/digital-resource-connector) from the connection attached to an asset in open metadata.  This is how a connector calls the technology it is cataloguing without having to know its credentials - they are held in the asset's connection, often through an embedded secrets store connector.
+
+For a connector that supports [catalog targets](/guides/developer/integration-connectors/catalog-targets), the framework has already done this: the resource connector for the target asset is available from `getConnectorToTarget()` on the catalog target processor.
+
+## Controlling what is exchanged
+
+* `getPermittedSynchronization()` returns the direction that metadata is allowed to flow for this connector or catalog target - `FROM_THIRD_PARTY`, `TO_THIRD_PARTY`, `BOTH_DIRECTIONS` or `OTHER`.  Check it before writing to either side.
+* `elementShouldBeCatalogued(elementName, excludedNames, includedNames)` applies the standard include/exclude list semantics used by Egeria's connectors, so that operators get consistent behaviour.  The include list takes precedence over the exclude list.
+* `getMetadataSourceQualifiedName()` and `getMetadataSourceGUID()` identify the [software capability](/concepts/software-capability) that owns the [metadata collection](/concepts/metadata-collection) the connector is maintaining.  When these are set, new elements are created with [external metadata provenance](/features/metadata-provenance/overview), which stops other tools from changing them.
+* `getIntegrationConnectorGUID()` returns the unique identifier of the *IntegrationConnector* element that describes this running connector - needed if the connector wants to manage its own [catalog targets](/guides/developer/integration-connectors/self-registering-integration-connectors).
+* `getMaxPageSize()` returns the largest number of results the server will return, for paging loops.
+
+## Listening for open metadata events
+
+```java
+        if (integrationContext.noListenerRegistered())
+        {
+            integrationContext.registerListener(this);
+        }
+```
+
+The listener implements [`OpenMetadataEventListener`](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataEventListener.html) and receives [`OpenMetadataOutTopicEvent`](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataOutTopicEvent.html) objects.
+
+`noRefreshInProgress()` tells the listener whether the connector is part-way through a `refresh()`.  Many of the events arriving during a refresh are caused by the connector's own updates, so ignoring events at this time avoids processing the same element twice:
+
+```java
+    @Override
+    public void processEvent(OpenMetadataOutTopicEvent event)
+    {
+        if (integrationContext.noRefreshInProgress())
+        {
+            :
+        }
+    }
+```
+
+Connectors that extend `DynamicIntegrationConnectorBase` get all of this for free - see [processing events for a catalog target](/guides/developer/integration-connectors/catalog-targets/#processing-events-for-a-catalog-target).
+
+## Refresh scheduling
+
+* `getRefreshStartTime()` - when the current refresh began.
+* `getNextScheduledRefreshTime()` - the earliest time the next refresh will run (null if refresh is only driven by explicit requests).
+* `getMinMinutesBetweenRefresh()` - the configured interval.
+
+These are useful for deciding how much work to attempt in one pass, and for writing meaningful audit log messages.
+
+## Integration iterators
+
+Comparing a large third party inventory with open metadata, page by page, is fiddly and easy to get wrong.  The OIF provides *integration iterators* to do it:
+
+* [`MetadataCollectionIterator` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/iterator/MetadataCollectionIterator.java){ target=gh } walks every element of a particular type within a metadata collection.
+* [`RelatedElementsIterator` :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/frameworks/open-integration-framework/src/main/java/org/odpi/openmetadata/frameworks/integration/iterator/RelatedElementsIterator.java){ target=gh } walks the elements related to a particular element.
+
+Each call to `getNextMember()` returns a `MemberElement`.  Ask it what to do with `getMemberAction()`, passing the creation and update times of the equivalent element in the third party technology.  It returns a `MemberAction` value - `CREATE_INSTANCE_IN_OPEN_METADATA`, `UPDATE_INSTANCE_IN_OPEN_METADATA`, `DELETE_INSTANCE_IN_OPEN_METADATA`, the three equivalents for the third party technology, or `NO_ACTION` - taking the permitted synchronization and the relative ages of the two copies into account.  `getMemberByQualifiedName()` looks up a specific element, and `moreToReceive()` controls the loop.
+
+## External identifiers
+
+Where the third party technology's identifiers cannot be folded into the `qualifiedName`, use `getExternalIdClient()` to attach [external identifiers](/features/external-identifiers/overview) to the open metadata elements.  As well as creating and linking them, `confirmSynchronization()` records that a particular element was checked against the third party technology on this pass, which supports the reporting of stale metadata.
+
+## Reporting activity
+
+The context assembles a [connector activity report](/concepts/integration-report) describing the elements that the connector created, updated and deleted.  The clients call `reportElementCreation()`, `reportElementUpdate()` and `reportElementDelete()` for you as changes are made; the integration daemon calls `startRecording()` before each refresh and publishes the report afterwards.
+
+* `setActiveReportPublishing(flag)` turns report writing off and on - useful during a bulk load.
+* `publishReport()` writes a report at a point of your choosing.
+
+## Raising issues for people
+
+An integration connector often finds things that need a person's attention.  Rather than only writing an audit log message, it can create open metadata that appears in the user interfaces:
+
+* `createIncidentReport()` raises an [incident report](/features/incident-reporting/overview).
+* `openToDo()` creates a *To Do* assigned to a person or role.
+* `createNoteLogEntry()` adds an entry to a note log.
+* `registerContextEvent()` records a significant event - a release, an outage, an unexpected change - against the elements it affects.
+* `getNotificationManager()` returns the client for managing notification subscriptions.
+
+## Initiating governance
+
+* `getStewardshipAction()` returns a client that can `initiateEngineAction()`, `initiateGovernanceActionType()` and `initiateGovernanceActionProcess()`, so a connector can hand work over to a [governance action service](/concepts/governance-action-service) - for example, to survey a newly discovered database.
+* `createProcessFromGovernanceActionType()` and `createGovernanceActionProcess()` build new governance processes.
+* `getOpenGovernanceClient()` provides the full [Open Governance Framework](/frameworks/ogf/overview) interface.
+
+## Open lineage
+
+Connectors that handle [open lineage](/features/lineage-management/overview) events use `registerOpenLineageListener()` to receive them and `publishOpenLineageRunEvent()` to distribute them to the registered listeners.  This is how the OpenLineage receiver and the OpenLineage log store connectors work together inside one integration daemon.
+
+## Utilities
+
+* `getFileClassifier(fileSystemName, canonicalMountPoint, localMountPoint)` returns a `FileClassifier` that uses Egeria's reference data to work out the type, encoding and deployed implementation type of a file.
+* `registerDirectoryListener()` and `registerDirectoryTreeListener()` (with matching `unregister...` methods) call your listener whenever a file is created, changed or deleted under a directory.  This avoids the connector having to poll the file system, and avoids it creating its own threads.
+* `isTypeOf()` tests whether an element header is of - or inherits from - a named open metadata type.
+* `getAnchorGUID()` returns the anchor element for an element, from its *Anchors* classification.
+* The name case converters translate between the canonical format used by open metadata (`My Table Name`) and the conventions used by third party technologies: `fromCanonicalToSnakeCase()`, `fromSnakeToCanonicalCase()`, `fromCanonicalToCamelCase()`, `fromCamelToCanonicalCase()`, `fromCanonicalToKebabCase()` and `fromKebabToCanonicalCase()`.
+
+## Shutdown
+
+Once the connector has been disconnected, the context is no longer valid, and calls to it throw `UserNotAuthorizedException`.  Long-running loops should call `integrationContext.validateIsActive(methodName)` periodically so that they stop promptly when the integration daemon is shutting down.
+
+??? education "Further information"
+    - [Open Integration Framework (OIF)](/frameworks/oif/overview)
+    - [Open Metadata Framework (OMF)](/frameworks/omf/overview)
+    - [Supporting catalog targets](/guides/developer/integration-connectors/catalog-targets)
+
+--8<-- "snippets/abbr.md"

--- a/site/docs/guides/developer/integration-connectors/self-registering-integration-connectors.md
+++ b/site/docs/guides/developer/integration-connectors/self-registering-integration-connectors.md
@@ -3,15 +3,19 @@
 
 # Self-registering integration connectors
 
-You may wish to write an integration connector that searches for particular types of metadata elements and registered them as its own catalog targets for ongoing processing.
+Normally the [catalog targets](/concepts/catalog-target) for an integration connector are attached by a person, or by a [governance action service](/concepts/governance-action-service), when they decide that a particular resource should be managed by that connector.
+
+Sometimes the connector can work out for itself which elements it should be working with.  For example, a connector that maintains a data dictionary for every data sharing hub should pick up each new data sharing hub as it is created, without anyone having to remember to connect it.
 
 In this pattern:
 
 * The integration connector inherits from `DynamicIntegrationConnectorBase`.
 * The `start()` method is minimal, simply initializing any resources needed to perform the discovery of new metadata elements of interest.
-* The discovery logic is implemented in the `refresh()` method.  It compares the existing list of catalog targets with the list of interesting metadata elements retrieved form the metadata repositories.  Any new ones are added as catalog targets.  Any that are no longer of interest are removed.
-* The processing logic is implemented in the *Target Processor* class.
+* The discovery logic is implemented in the `refresh()` method.  It compares the existing list of catalog targets with the list of interesting metadata elements retrieved from the metadata repositories.  Any new ones are added as catalog targets.  Any that are no longer of interest are removed.
+* The processing logic is implemented in the [catalog target processor](/guides/developer/integration-connectors/catalog-targets) class.
 * The `disconnect()` method cleans up any resources.
+
+Everything else about the connector is the same as any other [catalog target connector](/guides/developer/integration-connectors/catalog-targets) - the only difference is who creates the *CatalogTarget* relationships.
 
 ## Integration connector implementation
 
@@ -26,11 +30,26 @@ public class MySelfRegisteringIntegrationConnector extends DynamicIntegrationCon
 }
 ```
 
-If the connector will also process events then it should also implement the [OpenMetadataEventListener](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataEventListener.html) interface and its `processEvent()` method.  If this interface is implemented, the `DynamicIntegrationConnectorBase` will register and event listener for you.
+If the connector will also process events then it should also implement the [OpenMetadataEventListener](https://odpi.github.io/egeria/org/odpi/openmetadata/frameworks/openmetadata/events/OpenMetadataEventListener.html) interface and its `processEvent()` method.  If this interface is implemented, the `DynamicIntegrationConnectorBase` will register an event listener for you.
 
 ### Start method
 
-Typically the `start()` method simply outputs an audit log message to indicate that it is starting up.
+Typically the `start()` method simply outputs an audit log message to indicate that it is starting up.  Remember to call `super.start()` so that the catalog targets manager is created.
+
+```java
+    @Override
+    public void start() throws ConnectorCheckedException, UserNotAuthorizedException
+    {
+        super.start();
+
+        final String methodName = "start";
+
+        auditLog.logMessage(methodName,
+                            LiskovAuditCode.STARTING_CONNECTOR.getMessageDefinition(connectorName,
+                                                                                    integrationContext.getMetadataAccessServer(),
+                                                                                    integrationContext.getMetadataAccessServerPlatformURLRoot()));
+    }
+```
 
 ### Refresh method
 
@@ -38,19 +57,25 @@ The `refresh()` method has three jobs to perform:
 
 * discover if there are new metadata elements of interest
 * register any new metadata elements as catalog targets
-* refresh all catalog targets
+* refresh all catalog targets - by calling `super.refresh()` at the end
 
-This code snippet shows how to discover the unique identifiers (GUIDs) of elements that are already catalog targets.
+The first step is to build the set of elements that are already catalog targets, so that they are not added twice.  `integrationContext.getIntegrationConnectorGUID()` returns the unique identifier of the *IntegrationConnector* element that describes this running connector, and `AssetClient` provides the methods to query and maintain its catalog targets.
+
 ```java
-try
+    @Override
+    public void refresh() throws ConnectorCheckedException, UserNotAuthorizedException
+    {
+        final String methodName = "refresh";
+
+        try
         {
-            Set<String>     = new HashSet<>();
+            Set<String> knownCatalogTargets = new HashSet<>();
 
             AssetClient assetClient = integrationContext.getAssetClient();
-            int startFrom = 0;
+            int         startFrom   = 0;
 
-            List<OpenMetadataRootElement> catalogTargetList  = assetClient.getCatalogTargets(integrationContext.getIntegrationConnectorGUID(),
-                                                                                             assetClient.getQueryOptions(startFrom, integrationContext.getMaxPageSize()));
+            List<OpenMetadataRootElement> catalogTargetList = assetClient.getCatalogTargets(integrationContext.getIntegrationConnectorGUID(),
+                                                                                            assetClient.getQueryOptions(startFrom, integrationContext.getMaxPageSize()));
 
             while (catalogTargetList != null)
             {
@@ -66,27 +91,40 @@ try
                 catalogTargetList = assetClient.getCatalogTargets(integrationContext.getIntegrationConnectorGUID(),
                                                                   assetClient.getQueryOptions(startFrom, integrationContext.getMaxPageSize()));
             }
+```
 
+The second step retrieves the elements that this connector is interested in, and attaches any that are not already catalog targets.  The query used here determines what the connector picks up; this example uses the [collection client](/guides/developer/integration-connectors/integration-context/#the-open-metadata-clients) restricted to the `DataSharingHub` type, but any of the context's clients can be used, and a search string, classification or governance zone filter can narrow it further.
+
+```java
             /*
              * Process any new data sharing hubs.
              */
-            CollectionClient collectionClient = integrationContext.getCollectionClient(OpenMetadataType.DATA_HUB.typeName);
+            CollectionClient collectionClient = integrationContext.getCollectionClient(OpenMetadataType.DATA_SHARING_HUB.typeName);
             startFrom = 0;
 
             List<OpenMetadataRootElement> dataSharingHubs = collectionClient.findCollections(null,
-                                                                                      collectionClient.getSearchOptions(startFrom, integrationContext.getMaxPageSize()));
+                                                                                             collectionClient.getSearchOptions(startFrom, integrationContext.getMaxPageSize()));
 
             while (dataSharingHubs != null)
             {
                 for (OpenMetadataRootElement dataSharingHub : dataSharingHubs)
                 {
-                    if ((dataSharingHub != null) && (! knownCatalogTargets.contains(dataSharingHub.getElementHeader().getGUID())) && (dataSharingHub.getProperties() instanceof DataSharingHubProperties dataSharingHubProperties))
+                    if ((dataSharingHub != null) &&
+                        (! knownCatalogTargets.contains(dataSharingHub.getElementHeader().getGUID())) &&
+                        (dataSharingHub.getProperties() instanceof DataSharingHubProperties dataSharingHubProperties))
                     {
                         /*
                          * This is a new data sharing hub.  Add it as a catalog target.
                          */
+                        auditLog.logMessage(methodName,
+                                            LiskovAuditCode.NEW_DATA_HUB.getMessageDefinition(connectorName,
+                                                                                              dataSharingHubProperties.getDisplayName(),
+                                                                                              dataSharingHub.getElementHeader().getGUID()));
+
                         CatalogTargetProperties catalogTargetProperties = new CatalogTargetProperties();
+
                         catalogTargetProperties.setCatalogTargetName(dataSharingHubProperties.getDisplayName() + "(" + dataSharingHub.getElementHeader().getGUID() + ")");
+
                         assetClient.addCatalogTarget(integrationContext.getIntegrationConnectorGUID(),
                                                      dataSharingHub.getElementHeader().getGUID(),
                                                      assetClient.getMakeAnchorOptions(false),
@@ -94,9 +132,9 @@ try
                     }
                 }
 
-                startFrom = startFrom + integrationContext.getMaxPageSize();
-                dataSharingHubs  = collectionClient.findCollections(null,
-                                                             collectionClient.getSearchOptions(startFrom, integrationContext.getMaxPageSize()));
+                startFrom       = startFrom + integrationContext.getMaxPageSize();
+                dataSharingHubs = collectionClient.findCollections(null,
+                                                                   collectionClient.getSearchOptions(startFrom, integrationContext.getMaxPageSize()));
             }
         }
         catch (Exception error)
@@ -111,16 +149,55 @@ try
         super.refresh();
     }
 ```
-It is up to the implementation to determine how to discover the metadata elements of interest.  However using appropriate queries, it should be possible to identify anly elements that are not in 
 
+The final call to `super.refresh()` is what causes `DynamicIntegrationConnectorBase` to pick up the catalog targets - including the ones just added - create a processor for each new one, and call `refresh()` on all of them.
 
+It is up to the implementation to determine how to discover the metadata elements of interest.  However, using appropriate queries, it should be possible to identify any elements that are not yet catalog targets.  The `CatalogTargetProperties` you supply behave exactly as they would if a person had attached the target, so the connector can set the catalog target name, configuration properties, templates, metadata source name and permitted synchronization for each element it discovers.
 
+!!! tip "Give each catalog target a meaningful name"
+    The `catalogTargetName` appears in the audit log messages produced as each target is refreshed.  Including the element's display name, as this example does, makes those messages much easier for an operator to follow.
 
+### Removing catalog targets
 
+Elements that are no longer of interest should be removed so that the connector stops working on them:
+
+```java
+            assetClient.removeCatalogTarget(integrationContext.getIntegrationConnectorGUID(),
+                                            elementGUID,
+                                            assetClient.getDeleteOptions(false));
+```
+
+The framework detects the removal on the next refresh, disconnects the resource connector for that target and calls `disconnect()` on its catalog target processor.
+
+Be careful to only remove the catalog targets that this connector created.  If people are also allowed to attach targets by hand, an over-eager clean-up will silently undo their work.
+
+### Disconnect method
+
+The `disconnect()` method logs a shutdown message and calls `super.disconnect()` to release the resource connectors held by the catalog targets.
+
+```java
+    @Override
+    public void disconnect() throws ConnectorCheckedException
+    {
+        final String methodName = "disconnect";
+
+        auditLog.logMessage(methodName,
+                            LiskovAuditCode.CONNECTOR_STOPPING.getMessageDefinition(connectorName,
+                                                                                    integrationContext.getMetadataAccessServer(),
+                                                                                    integrationContext.getMetadataAccessServerPlatformURLRoot()));
+
+        super.disconnect();
+    }
+```
+
+Note that this does *not* remove the catalog targets from open metadata.  They are part of the connector's configuration and should survive a restart.
 
 ???+ info "Code Example"
-    See the [LiskovDataSharingHubManagerConnector](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/liskov/DataSharingHubManagerConnector.java)
+    See the [Data Sharing Hub Manager Connector :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/liskov/DataSharingHubManagerConnector.java){ target=gh } and its [target processor :material-github:](https://github.com/odpi/egeria/blob/main/open-metadata-implementation/adapters/open-connectors/nanny-connectors/src/main/java/org/odpi/openmetadata/adapters/connectors/liskov/DataSharingHubManagerTargetProcessor.java){ target=gh }.
 
-
+??? education "Further information"
+    - [Supporting catalog targets](/guides/developer/integration-connectors/catalog-targets)
+    - [The integration context](/guides/developer/integration-connectors/integration-context)
+    - [Catalog target](/concepts/catalog-target) concept page
 
 --8<-- "snippets/abbr.md"

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -174,6 +174,8 @@ nav:
           - Building Connectors:
               - Integration Connectors:
                     - Anatomy: guides/developer/integration-connectors/index.md
+                    - Catalog Targets: guides/developer/integration-connectors/catalog-targets.md
+                    - Integration Context: guides/developer/integration-connectors/integration-context.md
                     - Self-Registering: guides/developer/integration-connectors/self-registering-integration-connectors.md
               - Survey Action Services: guides/developer/survey-action-services/overview.md
               - Governance Action Services: guides/developer/governance-action-services/overview.md


### PR DESCRIPTION
# Update the integration connector developer guide for catalog targets

Rewrites `site/docs/guides/developer/integration-connectors` around the two big changes since the section was written: **catalog target support**, and the **removal of the integration services**.

## Why

The developer guide still described the world before catalog targets. It told developers to extend `IntegrationConnectorBase` (or one of the old `XXXIntegratorConnector` classes), to put all their logic in the connector's own `refresh()` method, and to find their third party technology through the endpoint on the connector's own connection. That model meant one deployed connector instance per resource — three databases to catalog, three configured connectors.

With catalog targets, the connector is deployed once (typically from a content pack) and people attach the resources they want it to work with using a *CatalogTarget* relationship, while it runs. That is a much simpler operational story, but it changes how connectors are built: they extend `DynamicIntegrationConnectorBase`, and the per-resource logic moves into a `CatalogTargetProcessorBase` subclass. None of that was documented.

The guide also still referred in places to choosing the right integration service interface, which no longer exists — all function is now reached through the single OIF context.

## What changed

### New pages

**`catalog-targets.md`** — *Supporting catalog targets*. The main new content:

- why catalog targets change the way connectors are built, and what it means operationally
- the connector / catalog target processor split, and what `DynamicIntegrationConnectorBase` does on each refresh
- writing the connector — `getNewRequestedCatalogTargetSkeleton()`, and when to override `start()`
- writing the processor — `start()`, `refresh()`, `disconnect()`, the properties available on `this`, and the `CatalogTargetProcessorBase` helper methods (`throwWrongTypeOfCatalogTarget()`, the typed configuration-property accessors, `setUpMetadataSource()`)
- processing open metadata events and third party events per catalog target
- `CatalogTargetChangeListener`
- a step-by-step recipe for migrating a pre-catalog-target connector

**`integration-context.md`** — *The integration context*. Calls out the improvements to the context object:

- the `ConnectorContextBase` → `IntegrationContext` → `CatalogTargetContext` hierarchy, and why each catalog target gets its own context
- the per-element-type open metadata clients and the options objects that qualify every request
- `getConnectedAssetContext().getConnectorForAsset()` for calling the third party technology
- permitted synchronization, `elementShouldBeCatalogued()`, metadata source and provenance
- the integration iterators and `MemberAction`, which implement the "delete what is no longer in the source" phase of a refresh
- external identifiers and `confirmSynchronization()`
- connector activity reports
- raising incident reports, To Dos, note log entries and context events
- initiating governance actions, open lineage, and the file/name-case utilities

### Rewritten pages

**`index.md`**
- restored a broken snippet include — `snippets/connectors/integration-connector-intro.md` was deleted in `afbd6a1d`, so the page had been rendering a dead reference at the top
- reframed the connection patterns as a tab set with catalog targets first, explicit endpoint second
- code samples updated to the current API (`connectionBean` not `connectionProperties`, `Endpoint.getNetworkAddress()` not `EndpointProperties.getAddress()`, `integrationContext` not `getIntegrationContext()`, `noRefreshInProgress()` not `isRefreshInProgress()`)
- example connector changed from the old `FilesIntegratorConnector` sample to `DynamicIntegrationConnectorBase`
- notes on how catalog targets change error handling (one failing target no longer stops the others) and audit logging
- fixed the metadata-destination diagram, which was showing the metadata-source image, and completed a sentence that ended mid-word

**`integration-connector-interface.md`**
- corrected the dependency list — it named `topic-integrator-api`, `data-manager-api` and `integration-daemon-services-api`, none of which are the modules a connector builds against now; added a Gradle variant alongside the Maven one
- added a tab set for choosing between `DynamicIntegrationConnectorBase` and `IntegrationConnectorBase`
- added an explicit note that the integration services have been removed, with the mechanical migration mapping
- lifecycle method descriptions updated for the catalog target flow and for calling `super`

**`implementing-an-integration-connector-provider.md`**
- replaced the hand-built `ConnectorType` example with `IntegrationConnectorProvider` + `OpenConnectorDefinition`
- documents `catalogTargets`, `supportedTechnologyTypes`, `supportedConfigurationProperties`, `setRefreshTimeInterval()` and `setUsesBlockingCalls()`
- new section on defining `CatalogTargetType` values, with the `PostgresTarget` enum as the example

**`self-registering-integration-connectors.md`**
- the page ended mid-sentence and its code sample would not compile (`Set<String>  = new HashSet<>();`, and a type name that no longer exists); completed it with working code from the Data Sharing Hub Manager connector
- added removing catalog targets, the `disconnect()` method, and an explanation of why the closing `super.refresh()` matters

### Elsewhere

- `concepts/integration-connector.md` — removed the last surviving reference to connectors running in an Open Metadata Integration Service and being "dependent on a specific OMIS"
- `mkdocs.yml` — added the two new pages to the nav

## Verification

- `mkdocs build` is clean; no new warnings
- every internal link and heading anchor used by these pages resolves in the built site, including the anchors that live inside the included snippet fragments
- every `github.com/odpi/egeria/blob/main/...` link added points at a path that exists on `origin/main`
- the mermaid diagrams and tab sets render

## Note

While checking the event-registration behaviour to document it, the guard in `DynamicIntegrationConnectorBase.refresh()` turned out to mix `&&` and `||` without parentheses, so it reads as `(noListenerRegistered && sync == BOTH_DIRECTIONS) || sync == TO_THIRD_PARTY` — meaning a `TO_THIRD_PARTY` connector re-registers its listener on every refresh. The docs here describe the intended behaviour; the code fix is going up separately against `egeria`.