### PR TITLE
Describe new Liskov function

### DIFF
--- a/site/docs/concepts/data-sharing-hub.md
+++ b/site/docs/concepts/data-sharing-hub.md
@@ -7,6 +7,16 @@ A *data sharing hub* is a [collection](/concepts/collection) of data [assets](/c
 
 The hub is the shop window.  Rather than each team negotiating access to each data store individually, the assets that an organization or team is willing to share are gathered in one place, with the conditions attached to them.  A consumer can then see what is available before asking for anything.
 
+## Describing what is on offer
+
+A shop window is only useful if the goods in it are labelled.  Membership of a hub therefore carries an expectation: the metadata describing the members is actively maintained and improved, rather than captured once and left to age.
+
+Egeria takes that on.  The contents of each member are catalogued, so that what is inside it is visible and not just the store itself, and the members are surveyed repeatedly so that what is recorded about the data reflects the data as it is now rather than as it was when the member joined the hub.
+
+From those descriptions a [data dictionary](/concepts/data-dictionary) is derived and anchored to the hub: an abstracted list of the [data fields](/concepts/data-field) and [data structures](/concepts/data-structure) found across the members.  A data field identifies similar data wherever it occurs, so a consumer can ask for the data they want once rather than once per data store, without needing to know which database or file holds it.  The generated dictionary carries the fields and their types; the descriptions that explain what the values mean are added by the people who know.  Each entry stays linked to the schema elements it was derived from, so a request expressed against the dictionary can be traced back to the data that satisfies it.
+
+The [Harvest and Publish](/patterns/harvest-and-publish/overview) pattern describes how this is kept up to date, and how a hub feeds a catalog of [digital products](/concepts/digital-product) once the demand for particular data becomes clear.
+
 ## Requesting data
 
 A *data sharing request* is the corresponding ask: a request to another party that they share data.  It is a type of [to do](/concepts/to-do), because satisfying it involves work by a person or a process.  The request tracks its own status and gathers the detail of what was asked for - typically a [data specification](/concepts/data-specification) describing the data required - together with the resulting data sharing agreement and any supporting resources.
@@ -16,5 +26,6 @@ Where the sharing arrangement is ongoing rather than one-off, it is usually expr
 ???+ info "Additional information"
     * The *DataSharingHub* and *DataSharingRequest* types are described in [Model 0705 Data Sharing](/types/7/0705-Data-Sharing).
     * The [Collection Manager API](/services/omvs/collection-manager/overview) provides the interface for working with data sharing hubs.
+    * The [Harvest and Publish](/patterns/harvest-and-publish/overview) pattern covers data sharing hubs alongside the Open Metadata Digital Product Catalog.
 
 --8<-- "snippets/abbr.md"

--- a/site/docs/features/duplicate-management/overview.md
+++ b/site/docs/features/duplicate-management/overview.md
@@ -261,7 +261,7 @@ Whenever the filtering changes the number of relationships being returned, the r
 Deduplication has to be suppressed for the processes that manage the duplicates, otherwise they would be unable to see the instances they are working on:
 
 * When a request is made with `forDuplicateProcessing` set to `true`, none of the processing described above takes place.  The entity that was retrieved is returned as it stands, with no peers gathered and no classifications merged, and every relationship is returned including the `PeerDuplicateLink` and `ConsolidatedDuplicateLink` relationships themselves.  This is the mode used by the governance actions that detect and link duplicates, by the [Mendel Automated Duplicate Manager](#the-mendel-automated-duplicate-manager) for every read and write it makes, and by the stewardship interfaces such as the [Classification Explorer](/services/omvs/classification-explorer/overview) that the steward uses to confirm them.
-* Requests that count matching entities or relationships rather than returning them are not filtered either.  Producing a deduplicated count would mean retrieving every matching instance, which defeats the purpose of a count operation.  A count may therefore be higher than the number of instances a retrieval would return.
+* Requests that count matching entities or relationships rather than returning them are not filtered by default, so a count can be higher than the number of instances a retrieval would return.  The caller chooses which they want with the `pushDown` parameter on the count operations.  With `pushDown` set to `true` - the default - the repository counts the matching rows itself, which never materializes an instance and is therefore fast, but counts what matches the search rather than what the caller would be given.  With `pushDown` set to `false` the instances are retrieved and counted, so the answer agrees with the list by construction, at the cost of reading every one of them.  Deduplication is only one of the reasons the two answers differ - a retrieval also drops the instances whose anchor the caller is not authorized to read.
 
 ## Automated duplicate management
 
@@ -270,7 +270,7 @@ The duplicate detection in figures 5 and 6 is deliberately pluggable, because mo
 Egeria's automated duplicate management works on that case, and it comes in two halves:
 
 * **Detection.**  When metadata is retrieved by a name that is supposed to be unique and more than one entity matches, the entities are linked to one another with candidate `PeerDuplicateLink` relationships.  Nothing else changes: no classifications are added, and the retrieval processing goes on returning the entities separately.
-* **Management.**  The [Mendel Automated Duplicate Manager](#the-mendel-automated-duplicate-manager) reviews those duplicate links.  It confirms the ones it is sure of, passes the rest to a steward, takes the classifications back off the duplicates that a steward has separated, and consolidates the clusters that have grown large enough.
+* **Management.**  The [Mendel Automated Duplicate Manager](#the-mendel-automated-duplicate-manager) reviews those duplicate links.  It confirms the ones it is sure of, passes the rest to a steward, takes back its own confirmations when the grounds for them disappear, takes the classifications off the duplicates that are no longer combined with anything, and consolidates the clusters that have grown large enough.
 
 The two halves are independent of one another.  Detection leaves its record whether or not anyone is running Mendel, and Mendel works on every `PeerDuplicateLink` relationship in the ecosystem, however it was created - by detection, by a [governance action service](/concepts/governance-action-service), by a steward, or by a tool outside Egeria.
 
@@ -340,7 +340,7 @@ It is defined in the [core content pack](/content-packs/core-content-pack/overvi
 
 Mendel works across the whole open metadata ecosystem rather than through [catalog targets](/concepts/catalog-target), and every read and write it makes sets `forDuplicateProcessing` to `true`.  A connector that manages duplicates has to be able to see them: reading [the combined view](#requests-that-do-not-deduplicate) would mean seeing one element where there are three, with the relationships of all three merged onto it, which is neither what is stored nor what needs changing.
 
-Each refresh retrieves every `PeerDuplicateLink` relationship in the ecosystem and makes three passes over that one snapshot.
+Each refresh retrieves every `PeerDuplicateLink` relationship in the ecosystem and makes four passes over that one snapshot.
 
 ```mermaid
 flowchart TD
@@ -353,32 +353,41 @@ flowchart TD
     a **Referenceable**,
     and the same
     qualified name?`"}
-    C -->|yes| D["`Set the link to **VALIDATED**
-    and add **KnownDuplicate**
-    to both entities`"]
+    C -->|yes| D["`Set the link to **VALIDATED**,
+    record the grounds on it, and add
+    **KnownDuplicate** to both entities`"]
     C -->|no| E["`Raise a **to do** for the
     DuplicateMetadataSteward role`"]
-    B -->|"`**2.** DEPRECATED,
-    OBSOLETE`"| F{"Are any of the entity's
-    other duplicate links
-    still live?"}
+    B -->|"**2.** VALIDATED"| L{"Was this Mendel's
+    own decision?"}
+    L -->|no| Z(["Leave it
+    alone"])
+    L -->|yes| M{"Are the entities
+    still a close match?"}
+    M -->|yes| Z
+    M -->|no| N["`Move the link to **DEPRECATED**
+    and record why`"]
+    B -->|"`**3.** DEPRECATED,
+    OBSOLETE`"| F{"`Is the entity still
+    deduplicated by some other
+    route - a live peer link, or a
+    **ConsolidatedDuplicateLink**?`"}
+    F -->|yes| Z
     F -->|no| G["`Remove **KnownDuplicate**
     from the entity`"]
-    F -->|yes| H(["Leave the
-    entity alone"])
-    B -->|"**3.** VALIDATED"| I["Gather the cluster of
+    B -->|"**4.** VALIDATED"| I["Gather the cluster of
     entities that the validated
     links connect together"]
     I --> J{"`Has the cluster reached
     **duplicateClusterSize**?`"}
-    J -->|no| H
+    J -->|no| Z
     J -->|yes| K["Build the consolidated
     entity and link it to
     each member"]
 ```
-> **Figure 13:** The three passes that the Mendel Automated Duplicate Manager makes over the duplicate links
+> **Figure 13:** The four passes that the Mendel Automated Duplicate Manager makes over the duplicate links
 
-Because all three passes work from the same snapshot, the links that a refresh validates are consolidated by the *next* refresh rather than the one that validated them.  A duplicate link that can not be processed is logged and skipped, so one problem link does not stop the rest of the pass.
+Validated links are looked at twice - once by the pass that asks whether the decision still holds, and once by the pass that builds clusters out of the ones that do.  Because all four passes work from the same snapshot, the links that a refresh validates are consolidated by the *next* refresh rather than the one that validated them.  A link that a refresh withdraws is the exception: the new status is written back onto the snapshot as well as into the repository, so the two passes that follow see the decision that has just been made rather than the state the link was retrieved in.  A duplicate link that can not be processed is logged and skipped, so one problem link does not stop the rest of the pass.
 
 #### Pass one - the links waiting for a decision
 
@@ -392,7 +401,9 @@ This is the same reasoning that detection uses, and it is deliberately the only 
 
 Where the entities are a close match, the `statusIdentifier` of the link is moved to `VALIDATED` and the `KnownDuplicate` classification is added to each entity that does not already carry it.  Both are needed before the retrieval processing combines anything.  The outcome is recorded as `MENDEL-DUPLICATE-MANAGER-0004`.
 
-Where they are not, a [`ToDo`](/concepts/to-do) is created for a steward and recorded as `MENDEL-DUPLICATE-MANAGER-0005`.  The to do describes the decision to be made, and carries both entities as action targets named `duplicateElement` so that the steward can work on them directly.  It is assigned to the `DuplicateMetadataSteward` [person role](/types/1/0118-Actor-Roles), which Mendel creates the first time it needs it - recorded as `MENDEL-DUPLICATE-MANAGER-0003`.
+The status is what the retrieval processing acts on; the rest of what is written to the link is for whoever reads it afterwards.  The `steward` property holds Mendel's own userId, with `stewardTypeName` of `UserIdentity` and `stewardPropertyName` of `userId`; `source` names the connector; and `notes` records the grounds - the three tests above, and the fact that a pairing failing any of them is referred to a steward instead.  A steward looking at a pair of combined entities can therefore see that the decision was the connector's rather than a person's, and on what basis.  That distinction is what the [next pass](#pass-two---the-decisions-mendel-can-take-back) turns on.
+
+Where the entities are not a close match, a [`ToDo`](/concepts/to-do) is created for a steward and recorded as `MENDEL-DUPLICATE-MANAGER-0005`.  The to do describes the decision to be made, and carries both entities as action targets named `duplicateElement` so that the steward can work on them directly.  It is assigned to the `DuplicateMetadataSteward` [person role](/types/1/0118-Actor-Roles), which Mendel creates the first time it needs it - recorded as `MENDEL-DUPLICATE-MANAGER-0003`.
 
 !!! tip "Appoint someone to the role"
     The to dos are only useful once somebody holds the role they are assigned to.  Appointing one or more people to `DuplicateMetadataSteward` is the step that turns Mendel's referrals into decisions.
@@ -401,13 +412,33 @@ There is one to do per duplicate link.  Its qualified name is derived from the l
 
 The steward's side of the decision is the same either way: confirming the duplicates means moving the link to `VALIDATED` and adding `KnownDuplicate` to both entities, and rejecting them means moving the link to `DEPRECATED`.  Both are done through the [Classification Explorer](/services/omvs/classification-explorer/overview).
 
-#### Pass two - the links a steward has retired
+#### Pass two - the decisions Mendel can take back
 
-`DEPRECATED` and `OBSOLETE` mean that a steward has ruled that the entities are not duplicates after all.  Retiring the link is not enough on its own, because it is the `KnownDuplicate` classification on the entity that makes the retrieval processing look for peers at all.
+A close match can stop being one.  The usual way is that somebody corrects a qualified name - which is exactly what a pair that only ever shared a name by mistake looks like once the mistake is fixed.  Nothing else revisits a validated link, so without this pass the two entities would go on being combined for ever on the strength of a match that no longer exists.
 
-An entity becomes a candidate for having its classification removed when it is found at the end of a retired link, and is disqualified as soon as it is found at the end of a link that is not retired - a single live link is enough to mean the entity is still combined with something.  The classification is removed from the candidates that survive, and the removal is recorded as `MENDEL-DUPLICATE-MANAGER-0006`.
+Mendel therefore re-tests the close match rule on every validated link, and where the grounds have gone it withdraws its decision:
 
-#### Pass three - consolidating the clusters
+* The link is moved to `DEPRECATED` rather than deleted, so the decision stays visible and reversible.  Its `notes` are replaced with an explanation of what was withdrawn and why, including the fact that a steward who believes the entities really are duplicates can validate the link again.
+* The `KnownDuplicate` classifications are not touched here.  [Pass three](#pass-three---the-entities-that-are-no-longer-combined) takes them off once the entity is no longer deduplicated by any route, which is the same rule that applies when a steward retires a link.
+* The withdrawal is recorded as `MENDEL-DUPLICATE-MANAGER-0017`.
+
+!!! warning "Only Mendel's own decisions are reconsidered"
+    A steward's decision is a judgement the connector is not entitled to overturn - a steward may well validate a pair that was never a close match, and that is the normal case rather than an exception.  The two are told apart by the link's `updatedBy`: Mendel writes its decisions under its own userId, so a link last updated by anyone else was ruled on by somebody else and is left alone.
+
+A withdrawal does not break up a consolidated cluster.  The members of a cluster go on being reached through the entity that replaced them, whatever happens to the pairwise links behind it, and whether a cluster should be broken up is a steward's decision rather than a side effect of retiring the evidence that first justified it.  What the withdrawal does mean is that the cluster now rests on less than it did, so when either end of a withdrawn link belongs to a consolidated cluster, `MENDEL-DUPLICATE-MANAGER-0018` is raised at `ACTION` severity to put the question in front of a steward.
+
+#### Pass three - the entities that are no longer combined
+
+`DEPRECATED` and `OBSOLETE` mean that the link no longer stands - because a steward has ruled that the entities are not duplicates after all, or because [pass two](#pass-two---the-decisions-mendel-can-take-back) has withdrawn a decision of Mendel's own.  Retiring the link is not enough on its own, because it is the `KnownDuplicate` classification on the entity that makes the retrieval processing look for peers at all.
+
+The classification may only come off an entity that is not deduplicated by *either* route:
+
+* No live peer link.  An entity becomes a candidate when it is found at the end of a retired link, and is disqualified as soon as it is found at the end of a link that is not retired - a single live link is enough to mean the entity is still combined with something.
+* No `ConsolidatedDuplicateLink`.  The classification is also what gates the redirect to a consolidated entity, so taking it off a member of a consolidated cluster would silently detach that one member: it would start returning itself while the rest of the cluster went on returning the consolidated entity, which still carries the content merged from it.
+
+The classification is removed from the candidates that survive both tests, and the removal is recorded as `MENDEL-DUPLICATE-MANAGER-0006`.
+
+#### Pass four - consolidating the clusters
 
 Two entities are in the same cluster when there is a chain of `VALIDATED` links between them, so the clusters are the connected components of the graph that the validated links form.  Mendel builds those clusters from the snapshot and consolidates each one that has reached `duplicateClusterSize` members.  A cluster that is already linked to a consolidated entity is skipped.
 
@@ -415,11 +446,11 @@ Consolidation is an optimization rather than a prerequisite.  A smaller cluster 
 
 The consolidated entity is built from the cluster's members ordered latest first, using the update time of each member, or its creation time where it has never been updated:
 
+* **Type.**  The consolidated entity takes the type of the latest member.  The members of a cluster are not necessarily all of the same type - a steward can validate a duplicate link between entities of different types - so this choice governs what the rest of the merge is allowed to carry.
 * **Properties.**  The latest member's properties are taken first, and each earlier member then contributes any property that no later member supplied.  Nothing that a member knows about is lost, and where the members disagree the latest value wins.
 * **Qualified name.**  This is the one property that is not inherited.  The members are still there holding their own qualified names, and a qualified name is unique, so the consolidated entity is given a derived one: the original with the ISO-8601 time of the merge appended.  Without this the repository would reject the new entity as a duplicate of the very entities it is consolidating.
-* **Type.**  The consolidated entity takes the type of the latest member.
-* **Classifications.**  These are gathered in the same way as the [peer combination](#combining-the-peer-entities) gathers them, and for the same reason: a classification that only one member of the cluster carries is still information about the concept that the cluster describes.  The consolidated entity therefore carries one instance of every classification name found anywhere in the cluster, and where more than one member carries the same classification it is the most recently updated version that is kept.
-* **The `ConsolidatedDuplicate` classification.**  On top of the members' classifications, the consolidated entity is created with the `ConsolidatedDuplicate` classification, carrying a `statusIdentifier` of `VALIDATED` and a `source` naming the connector.  Without a validated `ConsolidatedDuplicate` classification the retrieval processing ignores the consolidated entity and goes on returning the members separately.
+* **Classifications.**  These are gathered in the same way as the [peer combination](#combining-the-peer-entities) gathers them, and for the same reason: a classification that only one member of the cluster carries is still information about the concept that the cluster describes.  The consolidated entity therefore carries one instance of every classification name found anywhere in the cluster, and where more than one member carries the same classification it is the latest member's version that is kept.  Four classifications are deliberately left behind: `KnownDuplicate` and `ConsolidatedDuplicate`, because the consolidated entity is the survivor of the cluster rather than another member of it; `Anchors`, because it is created as its own anchor; and [`Memento`](/concepts/memento), because one member being archived says nothing about the entity that replaces the whole cluster.
+* **The `ConsolidatedDuplicate` classification.**  On top of the members' classifications, and added last so that nothing picked up from a member can displace it, the consolidated entity is created with the `ConsolidatedDuplicate` classification, carrying a `statusIdentifier` of `VALIDATED` and a `source` naming the connector.  Without a validated `ConsolidatedDuplicate` classification the retrieval processing ignores the consolidated entity and goes on returning the members separately.
 * **Links to the members.**  Each member is linked to the consolidated entity with a `ConsolidatedDuplicateLink` relationship, created through the Classification Explorer's `linkConsolidatedDuplicateToSourceElement()` operation so that the stewardship API owns how a consolidated entity is tied to the entities it was built from.  The member is at end 1 and the consolidated entity at end 2, which is the direction the retrieval processing looks in.
 * **Relationships.**  The members' relationships are copied onto the consolidated entity, again latest member first.  The `PeerDuplicateLink` and `ConsolidatedDuplicateLink` relationships are not copied, and neither are the relationships between members of the same cluster - they describe the members' relationship to each other, not to the world.  The same relationship is never created twice between the same two entities, and where the type only permits one relationship at the consolidated entity's end - an [end cardinality](/concepts/uni-multi-link) of `AT_MOST_ONE` on the opposite end - the first one to be offered wins, which is the latest member's.
 
@@ -428,13 +459,35 @@ The consolidated entity is built from the cluster's members ordered latest first
 
 The result is recorded as `MENDEL-DUPLICATE-MANAGER-0007`.  From this point the retrieval processing returns the consolidated entity in place of any of its members, and the combining work is no longer done on each request.
 
+##### What the merge leaves behind
+
+A merge is a series of choices, and every choice discards something.  Rather than let that happen silently, each discarded value is written to the [audit log](/concepts/audit-log) at `DECISION` severity, naming the member it came from and the value that was kept instead, so that a steward can see exactly what the consolidated entity does not carry.
+
+Some content is dropped because a later member has already supplied it:
+
+| | |
+|---|---|
+| `MENDEL-DUPLICATE-MANAGER-0011` | A property value, because a more recently updated member supplies a different one.  The qualified name is left out of this check: the members are expected to disagree on it, and the consolidated entity takes neither value. |
+| `MENDEL-DUPLICATE-MANAGER-0013` | A classification, because a more recently updated member carries the same classification with different properties. |
+| `MENDEL-DUPLICATE-MANAGER-0015` | A relationship, because the type only permits one at the consolidated entity's end and a more recently updated member has supplied it. |
+
+The rest is dropped because the consolidated entity's type cannot hold it.  This is the cost of a cluster whose members are not all of the same type: the consolidated entity has one type, and content belonging to another member's type has nowhere to go.  Storing it anyway would have the repository reject the whole consolidation.
+
+| | |
+|---|---|
+| `MENDEL-DUPLICATE-MANAGER-0012` | A property that the consolidated entity's type does not define. |
+| `MENDEL-DUPLICATE-MANAGER-0014` | A classification that cannot be attached to the consolidated entity's type. |
+| `MENDEL-DUPLICATE-MANAGER-0016` | A property of a classification that the classification's own type does not define - which happens when a member was created against a different version of the open metadata types. |
+
+Where nothing is known about a type - its properties are not available, or a classification does not say which entities it can attach to - the value is passed on and the repository has the final say.
+
 #### Reacting to duplicate links as they appear
 
 Once the first refresh has worked through the backlog of duplicate links, Mendel registers a listener for open metadata events - recorded as `MENDEL-DUPLICATE-MANAGER-0009` - so that a new or updated duplicate link is reviewed as it occurs rather than waiting up to a day for the next refresh.  Registering the listener after the first refresh rather than at start up means the events for the links that refresh has just processed are not delivered as well.
 
 The listener is deliberately narrow:
 
-* Only the creation and update of a `PeerDuplicateLink` relationship is of interest.  A deleted link means the duplicates have been separated again, which needs no action, and the retirement and consolidation passes depend on all of the duplicate links attached to an entity rather than the one that changed, so they stay on the refresh cycle.
+* Only the creation and update of a `PeerDuplicateLink` relationship is of interest.  A deleted link means the duplicates have been separated again, which needs no action.  The other three passes stay on the refresh cycle: the retirement and consolidation passes depend on all of the duplicate links attached to an entity rather than the one that changed, and the pass that reconsiders Mendel's own decisions turns on a change to an *entity* - a corrected qualified name - which produces no duplicate link event at all.
 * An event whose link is not in one of the undecided statuses is ignored.  This is also what stops a loop: the update that Mendel makes to a link produces another event for the same relationship, and by then its status is `VALIDATED`.
 * Events are ignored while a refresh is in progress, so that a duplicate link is not worked on by both threads at once.
 

--- a/site/docs/patterns/harvest-and-publish/overview.md
+++ b/site/docs/patterns/harvest-and-publish/overview.md
@@ -24,7 +24,9 @@ An architecture built around a hub also gives the business a picture it can reas
 
 Maintaining a description of what a hub contains is exactly the sort of work that should not be done by hand.  The *Liskov Data Sharing Hub Manager* - named in recognition of [Barbara Liskov](https://en.wikipedia.org/wiki/Barbara_Liskov)'s work on data abstraction - is the [integration connector](/concepts/integration-connector) that does it.
 
-Liskov detects each data sharing hub as it is created and begins monitoring the data stores that are members of it.  From their schemas it builds an abstracted [data dictionary](/concepts/data-dictionary), anchored to the hub, containing:
+Liskov detects each data sharing hub as it is created and begins monitoring the data stores that are members of it.  On each refresh it does two things for every member: it [makes sure the member is being catalogued and surveyed](#keeping-the-hubs-members-described), so that there is an accurate and current description to work from, and it abstracts what that description contains into the hub's data dictionary.
+
+From the members' schemas it builds an abstracted [data dictionary](/concepts/data-dictionary), anchored to the hub and created the first time it is needed, containing:
 
 * **[Data fields](/concepts/data-field)** - the types of data value found in the hub.  A data field identifies *similar data in different data stores*, so a consumer asks for the data they want once, rather than once per store.
 * **[Data structures](/concepts/data-structure)** - the groupings of those fields that reflect how the data is organized.
@@ -35,6 +37,20 @@ The generated dictionary is complete but bare - it has the fields and their type
 
 Crucially, each entry in the dictionary stays linked to the schema elements it was derived from.  That linkage is what allows an automated pipeline to navigate from the fields a requester asked for to the actual tables and columns that hold them.
 
+### Keeping the hub's members described
+
+A data dictionary is only as good as the descriptions of the data stores it is built from, and those descriptions are not Liskov's to write - they come from the integration connectors and [survey action services](/concepts/survey-action-service) that specialize in each technology.  What Liskov does is make sure they are running, rather than waiting for somebody to notice that a member has never been described.
+
+Egeria's [content packs](/concepts/open-metadata-archive) define [governance action types](/concepts/governance-action-type) that catalog and survey each kind of technology, and link them to the [technology type](/concepts/deployed-implementation-type) they support with a [ResourceList](/types/0/0019-More-Information) relationship, qualified by what the resource is used for.  Liskov follows those links from each member's `deployedImplementationType` and, for every member it encounters:
+
+* **Enables cataloguing, if it is not already enabled.**  A cataloguing governance action type carries the integration connector that will do the work as a predefined action target, so Liskov treats cataloguing as already enabled when the member is one of that connector's [catalog targets](/concepts/catalog-target).  Otherwise it starts the governance action type, passing the member as the `newAsset` action target.  This is what reveals the *contents* of a member: cataloguing a file system directory creates the assets for the files inside it, and each of those files is then catalogued and surveyed in its own right - a CSV file has its own file-type-specific survey, which is what puts its columns within reach of the dictionary.
+* **Requests a survey.**  A fresh survey is started on every refresh, so that the description of what a member actually contains keeps pace with the data rather than reflecting the day the member joined the hub.
+
+Both kinds of request are [engine actions](/concepts/engine-action) that run asynchronously in a [governance engine](/concepts/governance-engine), so their results are picked up by a later refresh rather than the one that asked for them.  A request is skipped when an engine action started from the same governance action type is already running - or waiting to run - against the same member, so an outstanding request from an earlier refresh is never duplicated.  Liskov records the hub it is managing as the source of each request, and reports the requests it starts on the [audit log](/concepts/audit-log) as `LISKOV-DATA-HUB-MANAGER-0020` for cataloguing and `LISKOV-DATA-HUB-MANAGER-0021` for a survey.  A member whose `deployedImplementationType` matches no known technology type is reported as `LISKOV-DATA-HUB-MANAGER-0022` and left alone: nothing is registered that knows how to describe it.
+
+!!! tip "Turning off the surveys you do not want"
+    By default every survey registered for a member's technology type is run.  Most technology types register exactly one, but a file system directory registers four - `survey-folder`, `survey-folder-and-files`, `survey-all-folders` and `survey-all-folders-and-files` - and running all of them on every refresh is rarely worth the cost.  The `excludedSurveyRequestTypes` configuration property takes a comma-separated list of the surveys to skip.  Each value is either the survey's request type (`survey-folder`) or the qualified name of its governance action type (`FileSurvey::survey-folder`).  Set it on the connector's connection to apply to every data sharing hub, or on an individual [catalog target](/concepts/catalog-target) to apply to just that hub - where both are set, the catalog target's value wins.
+
 ### Managing data sharing requests
 
 A request for data is work, not just a record, so the *DataSharingRequest* entity is a type of [ToDo](/types/1/0135-Actions-For-People).  It tracks the status of the request and gathers its details: the [data specification](/concepts/data-specification) describing the data being asked for, the data sharing agreement, and the related resources.
@@ -44,7 +60,7 @@ This covers both directions of sharing.  A requester inside the organization can
 The benefit that turns out to matter most is auditability.  In the [patient data sharing hub](/practices/coco-pharmaceuticals/scenarios/patient-data-sharing-hub/overview) scenario, [Robbie Records](/practices/coco-pharmaceuticals/personas/robbie-records) is managing requests by hand: copying data into a new database per project, keeping a folder of documents describing each one, and exporting password-protected CSV files.  Reconstructing what happened for an auditor was a job in itself.  With the hub in place, the agreements, the users with access, and exactly what data was shared are all recorded as they happen, and the reports that demonstrate compliance can be produced on demand.
 
 !!! summary "Usage"
-    A data sharing hub turns ad-hoc data sharing into a managed service: a single description of what is on offer, a tracked request and agreement for each consumer, and a durable record of what was shared with whom.
+    A data sharing hub turns ad-hoc data sharing into a managed service: a single description of what is on offer - kept current by Liskov driving the cataloguing and surveys behind it - a tracked request and agreement for each consumer, and a durable record of what was shared with whom.
 
 ## From data sharing hub to digital product
 
@@ -71,7 +87,7 @@ The *Open Metadata Digital Product Catalog* is Egeria's own catalog of such prod
 | Component | Role |
 |-----------|------|
 | **Jacquard Digital Product Loom** | An integration connector that harvests open metadata and weaves it into digital products, each presented as a [tabular data set](/concepts/tabular-data-set), organized into the product catalog.  Named for [Joseph Marie Jacquard](https://en.wikipedia.org/wiki/Joseph_Marie_Jacquard). |
-| **Baudot Subscription Manager** | An integration connector that manages the subscriptions to those products, including issuing notifications to subscribers.  Named for [Emile Baudot](https://en.wikipedia.org/wiki/%C3%89mile_Baudot). |
+| **Baudot Subscription Manager** | A [watchdog action service](/concepts/watchdog-action-service) that manages the subscriptions to those products.  It watches the products for changes and the subscribers as they come and go, issues the resulting notifications, and is designed to run indefinitely rather than complete.  Named for [Emile Baudot](https://en.wikipedia.org/wiki/%C3%89mile_Baudot). |
 | **Wedgwood Data Provisioner** | A [governance action service](/concepts/governance-action-service), called from Baudot, that provisions the product data into the destination the subscriber supplied.  Named for [Thomas Wedgwood](https://en.wikipedia.org/wiki/Thomas_Wedgwood_(photographer)). |
 | **Babbage Analytical Engine** and **Lovelace Services** | An integration connector and the governance services it orchestrates, which analyse the content of open metadata and store the resulting insight as classifications.  These insights become the raw material for the observability products described below, and are covered by the [Metadata Insight](/patterns/metadata-insight/overview) pattern. |
 | **External harvester connectors** | Harvest data from sources outside the ecosystem and record the resulting insight in open metadata for Jacquard to publish. |
@@ -123,6 +139,7 @@ Consumers browse and subscribe through the [Product Catalog](/services/omvs/prod
     * [Model 0705 Data Sharing](/types/7/0705-Data-Sharing) - the data sharing hub and data sharing request types.
     * [Model 0710 Digital Products](/types/7/0710-Digital-Products), [0711 Agreements](/types/7/0711-Agreements) and [0712 Digital Subscription](/types/7/0712-Digital-Subscription) - the digital product, agreement and subscription types.
     * [Data dictionary](/concepts/data-dictionary), [data field](/concepts/data-field) and [data structure](/concepts/data-structure) - the elements Liskov maintains.
+    * [Governance action type](/concepts/governance-action-type) and [technology type](/concepts/deployed-implementation-type) - how Liskov finds the cataloguing and survey requests to make for each member of a hub.
     * [Tabular data set](/concepts/tabular-data-set) - the form every open metadata digital product takes.
     * [Metadata Insight](/patterns/metadata-insight/overview) - where the insight published by the observability products comes from.
 

--- a/site/docs/practices/coco-pharmaceuticals/scenarios/business-transformation.drawio
+++ b/site/docs/practices/coco-pharmaceuticals/scenarios/business-transformation.drawio
@@ -429,33 +429,42 @@
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-2" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fad7ac;strokeColor=#b46504;sketch=1;curveFitting=1;jiggle=2;" value="Patient Treatment&lt;div&gt;(Sales/Direct)&lt;/div&gt;" vertex="1">
-          <mxGeometry height="60" width="120" x="322" y="763" as="geometry" />
+          <mxGeometry height="60" width="120" x="253" y="775" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-3" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#dae8fc;strokeColor=#6c8ebf;sketch=1;curveFitting=1;jiggle=2;" value="Data Hub" vertex="1">
-          <mxGeometry height="67" width="120" x="322" y="873" as="geometry" />
+          <mxGeometry height="67" width="120" x="253" y="885" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-4" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;" value="new-drug-order" vertex="1">
-          <mxGeometry height="30" width="110" x="383" y="830" as="geometry" />
+          <mxGeometry height="30" width="110" x="314" y="842" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-5" edge="1" parent="1" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="Hadl3BJ_0JPdq3oytBZT-6">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="382" y="938" as="sourcePoint" />
+            <mxPoint x="313" y="950" as="sourcePoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-6" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;sketch=1;curveFitting=1;jiggle=2;" value="Manufacturing" vertex="1">
-          <mxGeometry height="60" width="120" x="322" y="995" as="geometry" />
+          <mxGeometry height="60" width="120" x="253" y="1007" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-7" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;" value="new-drug-order" vertex="1">
-          <mxGeometry height="30" width="80" x="390" y="950" as="geometry" />
+          <mxGeometry height="30" width="80" x="321" y="962" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-8" edge="1" parent="1" source="Hadl3BJ_0JPdq3oytBZT-9" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" target="Hadl3BJ_0JPdq3oytBZT-2">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-9" parent="1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fad7ac;strokeColor=#b46504;sketch=1;curveFitting=1;jiggle=2;" value="Hospital" vertex="1">
-          <mxGeometry height="60" width="120" x="322" y="654" as="geometry" />
+          <mxGeometry height="60" width="120" x="253" y="666" as="geometry" />
         </mxCell>
         <mxCell id="Hadl3BJ_0JPdq3oytBZT-10" parent="1" style="text;html=1;whiteSpace=wrap;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;rounded=0;" value="new-drug-order" vertex="1">
-          <mxGeometry height="30" width="110" x="383" y="721" as="geometry" />
+          <mxGeometry height="30" width="110" x="314" y="733" as="geometry" />
+        </mxCell>
+        <mxCell id="Hadl3BJ_0JPdq3oytBZT-11" parent="1" style="shape=tape;whiteSpace=wrap;html=1;size=0.2;" value="New Drug Order" vertex="1">
+          <mxGeometry height="60" width="209" x="193" y="551" as="geometry" />
+        </mxCell>
+        <mxCell id="Hadl3BJ_0JPdq3oytBZT-12" parent="1" style="shape=tape;whiteSpace=wrap;html=1;size=0.2;" value="New Recipe" vertex="1">
+          <mxGeometry height="60" width="209" x="437" y="551" as="geometry" />
+        </mxCell>
+        <mxCell id="Hadl3BJ_0JPdq3oytBZT-13" parent="1" style="shape=tape;whiteSpace=wrap;html=1;size=0.2;" value="New Procurement Order" vertex="1">
+          <mxGeometry height="60" width="209" x="681" y="548" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>


### PR DESCRIPTION
# Document the Mendel and Liskov enhancements, and correct Baudot's connector type

Documentation only.  Brings three pages up to date with two recent Egeria PRs, and fixes one factual error found along the way.

## Duplicate management — [odpi/egeria#9279](https://github.com/odpi/egeria/pull/9279)

`features/duplicate-management/overview.md`

The Mendel Automated Duplicate Manager now makes **four** passes over the `PeerDuplicateLink` relationships rather than three.  Figure 13 has been redrawn and the pass sections renumbered.

* **Pass one** now records *why* it decided: `steward` (Mendel's own userId), `stewardTypeName`, `stewardPropertyName`, `source` and `notes` carrying the close-match grounds.
* **Pass two is new** — Mendel re-tests the close-match rule on the links it validated itself and moves a link to `DEPRECATED`, with the reason recorded, when the grounds have gone (typically a corrected qualified name).  Only its own decisions are reconsidered; a steward's is never overturned, the two being told apart by the link's `updatedBy`.  `MENDEL-DUPLICATE-MANAGER-0017`, plus `0018` at `ACTION` severity when either end belongs to a consolidated cluster.
* **Pass three** now requires *both* no live peer link and no `ConsolidatedDuplicateLink` before removing `KnownDuplicate`, so a member cannot be silently detached from a cluster the rest of its members are still in.
* **Pass four** documents the classification merge that #9279 added, including the four deliberately excluded classifications (`KnownDuplicate`, `ConsolidatedDuplicate`, `Anchors`, `Memento`) and the ordering that stops `ConsolidatedDuplicate` being displaced.
* **New "What the merge leaves behind" section** covering the six `DECISION`-severity messages, split into content dropped because a later member won (`0011`, `0013`, `0015`) and content the consolidated entity's type cannot hold (`0012`, `0014`, `0016`).
* **Counts** are no longer simply un-deduplicated: the *Requests that do not deduplicate* section now covers the `pushDown` parameter and what the two answers differ by.

## Data sharing hub — [odpi/egeria#9283](https://github.com/odpi/egeria/pull/9283)

`patterns/harvest-and-publish/overview.md` and `concepts/data-sharing-hub.md`

The Liskov Data Sharing Hub Manager no longer only *reads* the members' schemas — it drives the cataloguing and surveys that produce them.

* New **"Keeping the hub's members described"** section: Liskov follows the `ResourceList` links from each member's `deployedImplementationType` to the technology type's catalog and survey governance action types, enables cataloguing when the member is not already a catalog target of the connector named as the action type's predefined target, and requests a fresh survey each refresh.  Covers the asynchronous engine actions, the guard against duplicating an outstanding request, why cataloguing a directory brings its files into scope, and audit codes `LISKOV-DATA-HUB-MANAGER-0020`/`0021`/`0022`.
* Documents the new **`excludedSurveyRequestTypes`** configuration property, including why it exists (a file system directory registers four surveys against one for most technology types) and that a value set on a catalog target overrides one set on the connection.
* `concepts/data-sharing-hub.md` gains a concept-level **"Describing what is on offer"** section — the members' metadata is actively maintained and improved rather than captured once, and a data dictionary is derived from it — with links to the Harvest and Publish pattern for the detail.

## Correction

`patterns/harvest-and-publish/overview.md` described the **Baudot Subscription Manager** as an integration connector.  It is a [watchdog action service](https://egeria-project.org/concepts/watchdog-action-service/) — `BaudotSubscriptionManagementProvider extends WatchdogActionServiceProvider` — so the row now says so, along with the two things that follow: it watches both the products and the subscribers, and it runs indefinitely rather than completing.

## Verification

* `mkdocs build` from `site/` is clean, with no warnings on any of the changed pages.
* Absolute links, relative links and in-page anchors swept on all three pages — no dead targets.
* Every behavioural statement was checked against the Egeria source rather than inferred from the type model: method signatures, property names, audit message IDs and severities all come from the connector, handler and message-set classes in the two PRs.