### PR TITLE
Update GitHub Actions to v7

### DIFF
--- a/.github/workflows/merge-mkdocs.yml
+++ b/.github/workflows/merge-mkdocs.yml
@@ -10,8 +10,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: 3.x
       - run: pip install mkdocs-material

--- a/.github/workflows/pr-mkdocs.yml
+++ b/.github/workflows/pr-mkdocs.yml
@@ -10,8 +10,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: 3.x
       - run: pip install mkdocs-material


### PR DESCRIPTION
Bumps `actions/checkout` and `actions/setup-python` from **v4 to v7** in both mkdocs workflows.

Supersedes #905, the dependabot PR open since March 2024, which only bumped `setup-python` to v5 — two majors behind current.

## Why go straight to v7

| | checkout | setup-python |
|---|---|---|
| `main` before this | v4 | v4 |
| #905 would give | — | v5 (Dec 2023) |
| This PR | **v7** | **v7** |

Both workflows pass only `python-version: 3.x`, which is unchanged across all of these major versions, so the upgrade is a drop-in for this usage:

- **v5** — node16 to node20
- **v6** — node20 to node24; requires runner v2.327.1 or later, satisfied by `ubuntu-latest`
- **v7** — ESM migration; removes the `pip-install` input, which neither workflow uses

The `v7` moving tags were confirmed to exist on both actions, and both workflow files were checked to still parse with all steps intact.

## Validation

`pr-mkdocs.yml` runs on this PR and exercises both upgraded actions, so a green check here demonstrates the same `checkout` + `setup-python` + `mkdocs build` path that `merge-mkdocs.yml` uses to deploy the site.
