### PR TITLE
Update to bitol support in release note

### DIFF
--- a/site/docs/types/2/0215-Software-Components.md
+++ b/site/docs/types/2/0215-Software-Components.md
@@ -28,7 +28,7 @@ The *TransientEmbeddedProcess* entity describes an *EmbeddedProcess* entity that
 
 ## FunctionCall entity
 
-he *FunctionCall* entity describes a call to an external function.
+The *FunctionCall* entity describes a call to an external function.
 
 ## ProcessHierarchy relationship
 

--- a/site/snippets/release-notes/6-2.md
+++ b/site/snippets/release-notes/6-2.md
@@ -13,6 +13,9 @@ _**These are DRAFT release notes.  The notes will be updated until and when 6.2 
     * The [*PrimaryKey*](/types/5/0581-Data-Field-Implementation) classification may now be attached to a *DataField* as well as a *RelationalColumn*.
     * End 1 of the [*ContactThrough*](/types/1/0111-Contact-Details) relationship is now *Referenceable* rather than *ActorProfile*, so that, for example, digital products and data sharing agreements can record their support channels.
 
+??? functional "File and folder catalog templates honour the deployedImplementationType placeholder"
+    The data file, media file, software file and folder templates in the [Files Content Pack](/content-packs/files-content-pack/overview) declare a `deployedImplementationType` placeholder.  They now substitute it into the asset they create, where previously the template's own type (for example `YAML File`) was always used.  Callers of these templates should supply the placeholder; the file cataloguers already do.
+
 ??? functional "Support for the Bitol Open Data Contract Standard (ODCS) and Open Data Product Standard (ODPS)"
     Egeria can now exchange data contracts and data product descriptors with the teams that keep them in git, using the [Bitol](https://bitol.io) open standards.  See [digital product management](/features/digital-product-management/overview) for the mapping to open metadata.
 


### PR DESCRIPTION
# Release note: file and folder catalog templates honour the deployedImplementationType placeholder

Companion to the egeria PR that catalogs Bitol document files as assets and makes the data asset templates substitute their `deployedImplementationType` placeholder.

- `snippets/release-notes/6-2.md` - adds a functional entry explaining that the data file, media file, software file and folder templates in the Files Content Pack now substitute the `deployedImplementationType` placeholder they declare (previously the template's own type was always used), and that callers of these templates should supply it.

The description of the document files being catalogued and linked as *Bitol Document* resources was already merged with the digital product management page in an earlier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)